### PR TITLE
Feature/remove senders addressees materials

### DIFF
--- a/frontend/src/app/data-entry/event/event.component.html
+++ b/frontend/src/app/data-entry/event/event.component.html
@@ -99,34 +99,13 @@
                                 Describe the events in this passage.
                             </p>
                         </div>
+                    </div>
+                    <div class="mb-5">
+                        <h3>Category</h3>
                         <div class="mb-4">
-                            <label class="form-label">Action labels</label>
-
-                            <ul class="list-group mb-3">
-                                <li class="list-group-item hstack">
-                                    <span>
-                                        delivering
-                                    </span>
-                                    <div class="ms-auto btn-group">
-                                        <button class="btn btn-primary" disabled>
-                                            <fa-icon [icon]="icons.edit"></fa-icon>
-                                        </button>
-                                        <button class="btn btn-danger" disabled>
-                                            <fa-icon [icon]="icons.remove"></fa-icon>
-                                        </button>
-                                    </div>
-                                </li>
-                            </ul>
-
-                            <div ngbDropdown>
-                                <button type="button" class="btn btn-primary" ngbDropdownToggle>
-                                    Add a label
-                                </button>
-                                <div ngbDropdownMenu>
-                                    <button ngbDropdownItem *ngFor="let label of labels">
-                                        {{label}}
-                                    </button>
-                                </div>
+                            <label for="" class="form-label">Select all categories that apply</label>
+                            <div class="d-flex flex-wrap" style="gap: .5em;">
+                                <span *ngFor="let category of categories" role="button" class="badge" [class]="category.selected ? 'text-bg-primary' : 'text-bg-secondary'" (click)="selectCategory(category)">{{category.label}}</span>
                             </div>
                         </div>
                     </div>

--- a/frontend/src/app/data-entry/event/event.component.ts
+++ b/frontend/src/app/data-entry/event/event.component.ts
@@ -1,5 +1,6 @@
 import { Component } from '@angular/core';
 import { faPencil, faPlus, faTimes } from '@fortawesome/free-solid-svg-icons';
+import { Category } from 'src/app/shared/types';
 
 @Component({
   selector: 'lc-event',
@@ -19,4 +20,43 @@ export class EventComponent {
         'secret communication',
         'penance',
     ];
+
+    categories: Category[] = [
+        {
+            label: 'Delivery',
+            selected: true
+        },
+        {
+            label: 'Secret communication',
+            selected: false
+        },
+        {
+            label: 'Public reading',
+            selected: true
+        },
+        {
+            label: 'Writing',
+            selected: false
+        },
+        {
+            label: 'Penance',
+            selected: false
+        },
+        {
+            label: 'Excommunication',
+            selected: false
+        },
+        {
+            label: 'Deliberate destruction',
+            selected: false
+        },
+        {
+            label: 'Healing',
+            selected: false
+        }
+    ];
+
+    public selectCategory(category: Category): void {
+        category.selected = !category.selected;
+    }
 }

--- a/frontend/src/app/data-entry/object/object.component.html
+++ b/frontend/src/app/data-entry/object/object.component.html
@@ -86,105 +86,14 @@
                             <input type="text" class="form-control" placeholder="Add a new designator">
                         </div>
                     </div>
+
                     <div class="mb-5">
-                        <h3>Sender</h3>
+                        <h3>Category</h3>
                         <div class="mb-4">
-                            <label class="form-label">Who is described as the (original) sender?</label>
-                            <div class="form-check">
-                                <input type="checkbox" class="form-check-input" checked>
-                                <label class="form-check-label">St. Radegund</label>
+                            <label for="" class="form-label">Select all categories that apply</label>
+                            <div class="d-flex flex-wrap" style="gap: .5em;">
+                                <span *ngFor="let category of categories" role="button" class="badge" [class]="category.selected ? 'text-bg-primary' : 'text-bg-secondary'" (click)="selectCategory(category)">{{category.label}}</span>
                             </div>
-                            <div class="form-check">
-                                <input type="checkbox" class="form-check-input">
-                                <label class="form-check-label">Unknown messenger</label>
-                            </div>
-                            <div class="form-check">
-                                <input type="checkbox" class="form-check-input">
-                                <label class="form-check-label">The nuns of Poitiers</label>
-                            </div>
-                            <div class="form-text">
-                                You can choose between the agents that have been added for this source.
-                            </div>
-                        </div>
-                        <div class="mb-4">
-                            <label class="form-label">
-                                How is this information presented in the text?
-                            </label>
-
-                            <select class="form-select">
-                                <option>Implied</option>
-                                <option selected>Mentioned</option>
-                                <option>Described</option>
-                            </select>
-                        </div>
-                        <div class="mb-4">
-                            <label class="form-label">
-                                Additional notes
-                            </label>
-                            <textarea class="form-control" rows="2"></textarea>
-                        </div>
-                    </div>
-                    <div class="mb-5">
-                        <h3>Addressee</h3>
-                        <div class="mb-4">
-                            <label class="form-label">Who is describe as the addressee?</label>
-                            <div class="form-check">
-                                <input type="checkbox" class="form-check-input">
-                                <label class="form-check-label">St. Radegund</label>
-                            </div>
-                            <div class="form-check">
-                                <input type="checkbox" class="form-check-input">
-                                <label class="form-check-label">Unknown messenger</label>
-                            </div>
-                            <div class="form-check">
-                                <input type="checkbox" class="form-check-input" checked>
-                                <label class="form-check-label">The nuns of Poitiers</label>
-                            </div>
-                            <div class="form-text">
-                                You can choose between the agents that have been added for this source.
-                            </div>
-
-                        </div>
-                        <div class="mb-4">
-                            <label class="form-label">
-                                How is this information presented in the text?
-                            </label>
-
-                            <select class="form-select">
-                                <option>Implied</option>
-                                <option selected>Mentioned</option>
-                                <option>Described</option>
-                            </select>
-                        </div>
-                        <div class="mb-4">
-                            <label class="form-label">
-                                Additional notes
-                            </label>
-                            <textarea class="form-control" rows="2"></textarea>
-                        </div>
-                    </div>
-                    <div class="mb-5">
-                        <h3>Material properties</h3>
-                        <div class="mb-4">
-                            <label class="form-label">Material</label>
-                            <input class="form-control" value="parchment">
-                        </div>
-                        <div class="mb-4">
-                            <label class="form-label">
-                                How is this information presented in the text?
-                            </label>
-
-                            <select class="form-select">
-                                <option>Implied</option>
-                                <option selected>Mentioned</option>
-                                <option>Described</option>
-                            </select>
-                        </div>
-                        <div class="mb-4">
-                            <label class="form-label">
-                                Additional notes
-                            </label>
-                            <textarea class="form-control" rows="2"></textarea>
                         </div>
                     </div>
                 </ng-template>

--- a/frontend/src/app/data-entry/object/object.component.ts
+++ b/frontend/src/app/data-entry/object/object.component.ts
@@ -1,10 +1,6 @@
 import { Component } from '@angular/core';
 import { faAdd, faCancel, faCheck, faTimes } from '@fortawesome/free-solid-svg-icons';
-
-interface Category {
-    label: string;
-    selected: boolean;
-}
+import { Category } from 'src/app/shared/types';
 
 @Component({
     selector: 'lc-object',

--- a/frontend/src/app/data-entry/object/object.component.ts
+++ b/frontend/src/app/data-entry/object/object.component.ts
@@ -1,6 +1,11 @@
 import { Component } from '@angular/core';
 import { faAdd, faCancel, faCheck, faTimes } from '@fortawesome/free-solid-svg-icons';
 
+interface Category {
+    label: string;
+    selected: boolean;
+}
+
 @Component({
     selector: 'lc-object',
     templateUrl: './object.component.html',
@@ -12,6 +17,33 @@ export class ObjectComponent {
         cancel: faCancel,
         remove: faTimes,
         add: faAdd,
+    }
+
+    categories: Category[] = [
+        {
+            label: 'Written by woman',
+            selected: true
+        },
+        {
+            label: 'Secret letter',
+            selected: true
+        },
+        {
+            label: 'Poem',
+            selected: false
+        },
+        {
+            label: 'Written by saint',
+            selected: true
+        },
+        {
+            label: 'Unknown author',
+            selected: false
+        }
+    ];
+
+    public selectCategory(category: Category): void {
+        category.selected = !category.selected;
     }
 
 }

--- a/frontend/src/app/shared/types.ts
+++ b/frontend/src/app/shared/types.ts
@@ -1,0 +1,4 @@
+export interface Category {
+    label: string;
+    selected: boolean;
+}


### PR DESCRIPTION
Accompanies #73 

Removes senders, addressees and material from the object form; adds a category selection to the object form and the event form (replacing 'Action labels' in the latter).

In the actual form, we'll probably want to have a searchable dropdown vel sim.