### PR TITLE
Feature/introspection on dev

### DIFF
--- a/backend/graphql_app/middleware.py
+++ b/backend/graphql_app/middleware.py
@@ -1,5 +1,21 @@
+import json
+from django.conf import settings
+
+
 class GraphQLAuthMiddleware:
     def resolve(self, next, root, info, **kwargs):
+        request = info.context
+
+        # Allow introspection queries to pass through in development mode.
+        if settings.DEBUG and self.is_introspection_query(request):
+            return next(root, info, **kwargs)
+
         if info.context.user.is_authenticated:
             return next(root, info, **kwargs)
+
         raise Exception("User is not authenticated")
+
+    def is_introspection_query(self, request):
+        data = json.loads(request.body)
+        query = data.get("query")  # type: str
+        return query.startswith("query IntrospectionQuery")

--- a/frontend/codegen.ts
+++ b/frontend/codegen.ts
@@ -1,7 +1,8 @@
+import { environment } from './src/environments/environment';
 import type { CodegenConfig } from '@graphql-codegen/cli'
 
 const config: CodegenConfig = {
-    schema: 'http://localhost:8000/api/graphql',
+    schema: `http://localhost:8000${environment.graphqlUrl}`,
     generates: {
         './generated/graphql.ts': {
             plugins: [

--- a/frontend/src/environments/environment.prod.ts
+++ b/frontend/src/environments/environment.prod.ts
@@ -5,5 +5,5 @@ export const environment = {
     assets: '/static/assets',
     version,
     apiUrl: '/api/',
-    graphqlUrl: '/graphql',
+    graphqlUrl: '/api/graphql',
 };

--- a/frontend/src/environments/environment.ts
+++ b/frontend/src/environments/environment.ts
@@ -9,7 +9,7 @@ export const environment = {
     assets: 'assets',
     version,
     apiUrl: '/api/',
-    graphqlUrl: '/graphql',
+    graphqlUrl: '/api/graphql',
 };
 
 /*


### PR DESCRIPTION
When trying to run type generation in the frontend, I ran into the issue that codegen's introspection call is blocked by our GraphQL middleware. This middleware blocks any non-authenticated requests, but since codegen's requests are done outside of our Angular application, it does not automatically sends along the authentication details.

The solution proposed here simply allows introspection calls when we are in development mode. This is less cumbersome than trying to get the session_id into codegen's requests, but I would be open for other suggestions!