### PR TITLE
filter admin inline fields

### DIFF
--- a/backend/core/admin.py
+++ b/backend/core/admin.py
@@ -1,4 +1,9 @@
 from django.contrib import admin
+from django.db.models.fields.related import RelatedField
+from django.db.models.query import QuerySet
+from django.http import HttpRequest
+import re
+
 
 named_fieldset = (
     "Name and description",
@@ -37,3 +42,13 @@ class EntityDescriptionAdmin(admin.ModelAdmin):
         contributions_fieldset,
         description_source_fieldset,
     ]
+
+
+def get_queryset_matching_parent_source(
+    admin: admin.StackedInline | admin.TabularInline,
+    db_field: RelatedField,
+    request: HttpRequest,
+) -> QuerySet:
+    parent_id = re.search(f"\d+", request.path).group(0)
+    parent = admin.parent_model.objects.get(id=parent_id)
+    return db_field.remote_field.model.objects.filter(source=parent.source)

--- a/backend/core/admin.py
+++ b/backend/core/admin.py
@@ -49,6 +49,10 @@ def get_queryset_matching_parent_source(
     db_field: RelatedField,
     request: HttpRequest,
 ) -> QuerySet:
-    parent_id = re.search(f"\d+", request.path).group(0)
-    parent = admin.parent_model.objects.get(id=parent_id)
-    return db_field.remote_field.model.objects.filter(source=parent.source)
+    id_match = re.search(r"\d+", request.path)
+    if id_match:
+        parent_id = id_match.group(0)
+        parent = admin.parent_model.objects.get(id=parent_id)
+        return db_field.remote_field.model.objects.filter(source=parent.source)
+    else:
+        return db_field.remote_field.model.objects.all()

--- a/backend/event/admin.py
+++ b/backend/event/admin.py
@@ -46,7 +46,7 @@ class EpisodeLetterAdmin(admin.StackedInline):
     verbose_name = "involved letter"
 
     def get_field_queryset(self, db, db_field, request):
-        if db_field.name == "letter":
+        if db_field.name == "letter" and request:
             return core_admin.get_queryset_matching_parent_source(
                 self, db_field, request
             )

--- a/backend/event/admin.py
+++ b/backend/event/admin.py
@@ -1,4 +1,3 @@
-from typing import Any
 from django.contrib import admin
 from . import models
 from core import admin as core_admin

--- a/backend/event/admin.py
+++ b/backend/event/admin.py
@@ -1,3 +1,4 @@
+from typing import Any
 from django.contrib import admin
 from . import models
 from core import admin as core_admin
@@ -15,12 +16,28 @@ class EpisodeAgentAdmin(admin.StackedInline):
     extra = 0
     verbose_name = "involved agent"
 
+    def get_field_queryset(self, db, db_field, request):
+        if db_field.name == "agent":
+            return core_admin.get_queryset_matching_parent_source(
+                self, db_field, request
+            )
+
+        return super().get_field_queryset(db, db_field, request)
+
 
 class EpisodeGiftAdmin(admin.StackedInline):
     model = models.EpisodeGift
     fields = ["gift"] + core_admin.description_field_fields
     extra = 0
     verbose_name = "involved gift"
+
+    def get_field_queryset(self, db, db_field, request):
+        if db_field.name == "gift":
+            return core_admin.get_queryset_matching_parent_source(
+                self, db_field, request
+            )
+
+        return super().get_field_queryset(db, db_field, request)
 
 
 class EpisodeLetterAdmin(admin.StackedInline):
@@ -29,12 +46,28 @@ class EpisodeLetterAdmin(admin.StackedInline):
     extra = 0
     verbose_name = "involved letter"
 
+    def get_field_queryset(self, db, db_field, request):
+        if db_field.name == "letter":
+            return core_admin.get_queryset_matching_parent_source(
+                self, db_field, request
+            )
+
+        return super().get_field_queryset(db, db_field, request)
+
 
 class EpisodeSpaceAdmin(admin.StackedInline):
     model = models.EpisodeSpace
     fields = ["space"] + core_admin.description_field_fields
     extra = 0
     verbose_name = "involved space"
+
+    def get_field_queryset(self, db, db_field, request):
+        if db_field.name == "space":
+            return core_admin.get_queryset_matching_parent_source(
+                self, db_field, request
+            )
+
+        return super().get_field_queryset(db, db_field, request)
 
 
 @admin.register(models.Episode)

--- a/backend/person/admin.py
+++ b/backend/person/admin.py
@@ -1,4 +1,9 @@
+from typing import Any
 from django.contrib import admin
+from django.db.models.fields.related import RelatedField
+from django.db.models.query import QuerySet
+from django.http import HttpRequest
+import re
 
 from . import models
 from core import admin as core_admin
@@ -41,6 +46,14 @@ class AgentDescriptionLocationAdmin(admin.StackedInline):
     model = models.AgentDescriptionLocation
     fields = ["location"] + core_admin.description_field_fields
     extra = 0
+
+    def get_field_queryset(
+        self, db, db_field: RelatedField, request: HttpRequest
+    ) -> QuerySet:
+        if db_field.name == "location":
+            core_admin.get_queryset_matching_parent_source(self, db_field, request)
+
+        return super().get_field_queryset(db, db_field, request)
 
 
 @admin.register(models.AgentDescription)

--- a/backend/person/admin.py
+++ b/backend/person/admin.py
@@ -1,9 +1,7 @@
-from typing import Any
 from django.contrib import admin
 from django.db.models.fields.related import RelatedField
 from django.db.models.query import QuerySet
 from django.http import HttpRequest
-import re
 
 from . import models
 from core import admin as core_admin
@@ -49,9 +47,11 @@ class AgentDescriptionLocationAdmin(admin.StackedInline):
 
     def get_field_queryset(
         self, db, db_field: RelatedField, request: HttpRequest
-    ) -> QuerySet:
+    ) -> QuerySet | None:
         if db_field.name == "location":
-            core_admin.get_queryset_matching_parent_source(self, db_field, request)
+            return core_admin.get_queryset_matching_parent_source(
+                self, db_field, request
+            )
 
         return super().get_field_queryset(db, db_field, request)
 

--- a/backend/person/admin.py
+++ b/backend/person/admin.py
@@ -46,9 +46,9 @@ class AgentDescriptionLocationAdmin(admin.StackedInline):
     extra = 0
 
     def get_field_queryset(
-        self, db, db_field: RelatedField, request: HttpRequest
+        self, db, db_field: RelatedField, request: HttpRequest | None
     ) -> QuerySet | None:
-        if db_field.name == "location":
+        if db_field.name == "location" and request:
             return core_admin.get_queryset_matching_parent_source(
                 self, db_field, request
             )


### PR DESCRIPTION
Small update to filter the querysets of some fields in the admin. E.g. when you select agents in an episode, you'll only see agents from the same source text. (As other agents are not valid choices.)

I was looking into this more out of curiosity than because it's high priority at the moment, but it does make the admin site more user-friendly.