### PR TITLE
Miscellaneous form fixes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,7 +44,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.10'
+        python-version: '3.9'
         cache: 'pip'
     - name: Use Node.js
       uses: actions/setup-node@v4

--- a/backend/core/admin.py
+++ b/backend/core/admin.py
@@ -3,7 +3,7 @@ from django.db.models.fields.related import RelatedField
 from django.db.models.query import QuerySet
 from django.http import HttpRequest
 import re
-
+from typing import Union
 
 named_fieldset = (
     "Name and description",
@@ -45,7 +45,7 @@ class EntityDescriptionAdmin(admin.ModelAdmin):
 
 
 def get_queryset_matching_parent_source(
-    admin: admin.StackedInline | admin.TabularInline,
+    admin: Union[admin.StackedInline, admin.TabularInline],
     db_field: RelatedField,
     request: HttpRequest,
 ) -> QuerySet:

--- a/backend/event/mutations/CreateEpisodeEntityLinkMutation.py
+++ b/backend/event/mutations/CreateEpisodeEntityLinkMutation.py
@@ -81,6 +81,7 @@ class CreateEpisodeEntityLinkMutation(LettercraftMutation):
         data: CreateEpisodeEntityLinkInput,
         info: ResolveInfo,
     ):
-        user = info.context.user
-        episode_entity_link.episode.contributors.add(user)
-        episode_entity_link.entity.contributors.add(user)
+        if info.context:
+            user = info.context.user
+            episode_entity_link.episode.contributors.add(user)
+            episode_entity_link.entity.contributors.add(user)

--- a/backend/event/mutations/CreateEpisodeEntityLinkMutation.py
+++ b/backend/event/mutations/CreateEpisodeEntityLinkMutation.py
@@ -65,6 +65,7 @@ class CreateEpisodeEntityLinkMutation(LettercraftMutation):
                 obj = LinkModel.objects.create(
                     **{"episode": episode, LinkModel.entity_field: entity}
                 )
+                cls.add_contribution(obj, data, info)
                 obj.clean()
         except ValidationError as e:
             errors = [
@@ -74,3 +75,12 @@ class CreateEpisodeEntityLinkMutation(LettercraftMutation):
             return cls(ok=False, errors=errors)
 
         return cls(ok=True, errors=[])
+
+    def add_contribution(
+        episode_entity_link: EpisodeEntity,
+        data: CreateEpisodeEntityLinkInput,
+        info: ResolveInfo,
+    ):
+        user = info.context.user
+        episode_entity_link.episode.contributors.add(user)
+        episode_entity_link.entity.contributors.add(user)

--- a/backend/event/mutations/CreateEpisodeMutation.py
+++ b/backend/event/mutations/CreateEpisodeMutation.py
@@ -41,8 +41,13 @@ class CreateEpisodeMutation(LettercraftMutation):
             name=getattr(episode_data, "name"),
             source=source,
         )
+        cls.add_contribution(episode, episode_data, info)
 
         user = info.context.user
         episode.contributors.add(user)
 
         return cls(episode=episode, errors=[])  # type: ignore
+
+    def add_contribution(obj: Episode, data: CreateEpisodeInput, info: ResolveInfo):
+        user = info.context.user
+        obj.contributors.add(user)

--- a/backend/event/mutations/CreateEpisodeMutation.py
+++ b/backend/event/mutations/CreateEpisodeMutation.py
@@ -49,5 +49,6 @@ class CreateEpisodeMutation(LettercraftMutation):
         return cls(episode=episode, errors=[])  # type: ignore
 
     def add_contribution(obj: Episode, data: CreateEpisodeInput, info: ResolveInfo):
-        user = info.context.user
-        obj.contributors.add(user)
+        if info.context:
+            user = info.context.user
+            obj.contributors.add(user)

--- a/backend/event/mutations/DeleteEpisodeEntityLinkMutation.py
+++ b/backend/event/mutations/DeleteEpisodeEntityLinkMutation.py
@@ -48,6 +48,7 @@ class DeleteEpisodeEntityLinkMutation(Mutation):
         return cls(ok=True, errors=[])
 
     def add_contribution(obj: EpisodeEntity, info: ResolveInfo):
-        user = info.context.user
-        obj.episode.contributors.add(user)
-        obj.entity.contributors.add(user)
+        if info.context:
+            user = info.context.user
+            obj.episode.contributors.add(user)
+            obj.entity.contributors.add(user)

--- a/backend/event/mutations/DeleteEpisodeEntityLinkMutation.py
+++ b/backend/event/mutations/DeleteEpisodeEntityLinkMutation.py
@@ -10,6 +10,7 @@ from graphene import (
 from graphql_app.types.LettercraftErrorType import LettercraftErrorType
 from core.types.entity import Entity
 from core.entity_models import ENTITY_MODELS
+from event.models import EpisodeEntity
 
 class DeleteEpisodeEntityLinkMutation(Mutation):
     ok = Boolean(required=True)
@@ -45,3 +46,8 @@ class DeleteEpisodeEntityLinkMutation(Mutation):
         obj.delete()
 
         return cls(ok=True, errors=[])
+
+    def add_contribution(obj: EpisodeEntity, info: ResolveInfo):
+        user = info.context.user
+        obj.episode.contributors.add(user)
+        obj.entity.contributors.add(user)

--- a/backend/event/mutations/UpdateEpisodeEntityLinkMutation.py
+++ b/backend/event/mutations/UpdateEpisodeEntityLinkMutation.py
@@ -60,6 +60,7 @@ class UpdateEpisodeEntityLinkMutation(LettercraftMutation):
         data: UpdateEpisodeEntityLinkInput,
         info: ResolveInfo,
     ):
-        user = info.context.user
-        obj.episode.contributors.add(user)
-        obj.entity.contributors.add(user)
+        if info.context:
+            user = info.context.user
+            obj.episode.contributors.add(user)
+            obj.entity.contributors.add(user)

--- a/backend/event/mutations/UpdateEpisodeEntityLinkMutation.py
+++ b/backend/event/mutations/UpdateEpisodeEntityLinkMutation.py
@@ -11,9 +11,9 @@ from graphene import (
 from graphql_app.LettercraftMutation import LettercraftMutation
 from graphql_app.types.LettercraftErrorType import LettercraftErrorType
 from core.types.DescriptionFieldType import SourceMentionEnum
-from event.models import EpisodeAgent
 from core.types.entity import Entity
 from core.entity_models import ENTITY_MODELS
+from event.models import EpisodeEntity
 
 
 class UpdateEpisodeEntityLinkInput(InputObjectType):
@@ -25,7 +25,7 @@ class UpdateEpisodeEntityLinkInput(InputObjectType):
 
 
 class UpdateEpisodeEntityLinkMutation(LettercraftMutation):
-    django_model = EpisodeAgent
+    django_model = EpisodeEntity
 
     ok = Boolean(required=True)
     errors = List(NonNull(LettercraftErrorType), required=True)
@@ -51,5 +51,15 @@ class UpdateEpisodeEntityLinkMutation(LettercraftMutation):
         cls.mutate_object(
             data, obj, info, excluded_fields=["entity", "entity_type", "episode"]
         )
+        cls.add_contribution(obj, data, info)
 
         return cls(ok=True, errors=[])
+
+    def add_contribution(
+        obj: EpisodeEntity,
+        data: UpdateEpisodeEntityLinkInput,
+        info: ResolveInfo,
+    ):
+        user = info.context.user
+        obj.episode.contributors.add(user)
+        obj.entity.contributors.add(user)

--- a/backend/event/mutations/UpdateEpisodeMutation.py
+++ b/backend/event/mutations/UpdateEpisodeMutation.py
@@ -39,8 +39,9 @@ class UpdateEpisodeMutation(LettercraftMutation):
             )
             return cls(ok=False, errors=[error])  # type: ignore
 
-        user = info.context.user
-        episode.contributors.add(user)
+        if info.context:
+            user = info.context.user
+            episode.contributors.add(user)
 
         episode.save()
 

--- a/backend/event/queries.py
+++ b/backend/event/queries.py
@@ -1,6 +1,7 @@
 from graphene import ID, Field, List, NonNull, ObjectType, ResolveInfo
 from django.db.models import QuerySet, Q
 from event.models import Episode, EpisodeCategory, EpisodeEntity
+from typing import Optional
 from event.types.EpisodeCategoryType import EpisodeCategoryType
 from event.types.EpisodeType import EpisodeType
 from event.types.EpisodeEntityLink import EpisodeEntityLink
@@ -20,7 +21,7 @@ class EventQueries(ObjectType):
     )
 
     @staticmethod
-    def resolve_episode(parent: None, info: ResolveInfo, id: str) -> Episode | None:
+    def resolve_episode(parent: None, info: ResolveInfo, id: str) -> Optional[Episode]:
         try:
             return EpisodeType.get_queryset(Episode.objects, info).get(id=id)
         except Episode.DoesNotExist:
@@ -30,7 +31,7 @@ class EventQueries(ObjectType):
     def resolve_episodes(
         parent: None,
         info: ResolveInfo,
-        source_id: str | None = None,
+        source_id: Optional[str] = None,
     ) -> QuerySet[Episode]:
         filters = Q() if source_id is None else Q(source_id=source_id)
 

--- a/backend/graphql_app/LettercraftMutation.py
+++ b/backend/graphql_app/LettercraftMutation.py
@@ -1,4 +1,4 @@
-from typing import Type
+from typing import Type, Optional
 from dataclasses import dataclass
 from graphene import InputObjectType, Mutation, ResolveInfo
 from django.db.models import Model
@@ -17,7 +17,7 @@ class LettercraftMutation(Mutation):
     An extension of Graphene's base Mutation class.
     """
 
-    django_model: Type[Model] | None = None
+    django_model: Optional[Type[Model]] = None
 
     @classmethod
     def get_object(cls, info: ResolveInfo, mutation_input: InputObjectType) -> Model:

--- a/backend/letter/queries.py
+++ b/backend/letter/queries.py
@@ -1,5 +1,6 @@
 from graphene import ID, Field, List, NonNull, ObjectType, ResolveInfo
 from django.db.models import QuerySet, Q
+from typing import Optional
 
 from letter.models import GiftDescription, LetterCategory, LetterDescription
 from letter.types.LetterCategoryType import LetterCategoryType
@@ -28,7 +29,7 @@ class LetterQueries(ObjectType):
     @staticmethod
     def resolve_letter_description(
         parent: None, info: ResolveInfo, id: str
-    ) -> LetterDescription | None:
+    ) -> Optional[LetterDescription]:
         try:
             return LetterDescriptionType.get_queryset(
                 LetterDescription.objects, info
@@ -40,8 +41,8 @@ class LetterQueries(ObjectType):
     def resolve_letter_descriptions(
         parent: None,
         info: ResolveInfo,
-        episode_id: str | None = None,
-        source_id: str | None = None,
+        episode_id: Optional[str] = None,
+        source_id: Optional[str] = None,
     ) -> QuerySet[LetterDescription]:
         filters = Q()
         if episode_id:
@@ -62,7 +63,7 @@ class LetterQueries(ObjectType):
     @staticmethod
     def resolve_gift_description(
         parent: None, info: ResolveInfo, id: str
-    ) -> GiftDescription | None:
+    ) -> Optional[GiftDescription]:
         try:
             return GiftDescriptionType.get_queryset(GiftDescription.objects, info).get(
                 id=id
@@ -74,8 +75,8 @@ class LetterQueries(ObjectType):
     def resolve_gift_descriptions(
         parent: None,
         info: ResolveInfo,
-        episode_id: str | None = None,
-        source_id: str | None = None,
+        episode_id: Optional[str] = None,
+        source_id: Optional[str] = None,
     ) -> QuerySet[GiftDescription]:
         filters = Q()
         if episode_id:

--- a/backend/person/admin.py
+++ b/backend/person/admin.py
@@ -2,6 +2,7 @@ from django.contrib import admin
 from django.db.models.fields.related import RelatedField
 from django.db.models.query import QuerySet
 from django.http import HttpRequest
+from typing import Optional
 
 from . import models
 from core import admin as core_admin
@@ -53,8 +54,8 @@ class AgentDescriptionLocationAdmin(admin.StackedInline):
     extra = 0
 
     def get_field_queryset(
-        self, db, db_field: RelatedField, request: HttpRequest | None
-    ) -> QuerySet | None:
+        self, db, db_field: RelatedField, request: Optional[HttpRequest]
+    ) -> Optional[QuerySet]:
         if db_field.name == "location" and request:
             return core_admin.get_queryset_matching_parent_source(
                 self, db_field, request

--- a/backend/person/mutations/CreateAgentMutation.py
+++ b/backend/person/mutations/CreateAgentMutation.py
@@ -40,7 +40,7 @@ class CreateAgentMutation(LettercraftMutation):
         try:
             with transaction.atomic():
                 cls.mutate_object(agent_data, agent, info)
-                cls._add_contribution(agent, agent_data, info)
+                cls.add_contribution(agent, agent_data, info)
                 agent.full_clean()
         except ValidationError as e:
             errors = [
@@ -51,7 +51,7 @@ class CreateAgentMutation(LettercraftMutation):
 
         return cls(ok=True, agent=agent, errors=[])
 
-    def _add_contribution(
+    def add_contribution(
         agent: AgentDescription, agent_data: CreateAgentInput, info: ResolveInfo
     ):
         if info.context:

--- a/backend/person/mutations/CreateAgentMutation.py
+++ b/backend/person/mutations/CreateAgentMutation.py
@@ -54,10 +54,11 @@ class CreateAgentMutation(LettercraftMutation):
     def _add_contribution(
         agent: AgentDescription, agent_data: CreateAgentInput, info: ResolveInfo
     ):
-        user = info.context.user
-        agent.contributors.add(user)
+        if info.context:
+            user = info.context.user
+            agent.contributors.add(user)
 
-        if agent_data.episodes:
-            for episode_id in agent_data.episodes:
-                episode = Episode.objects.get(id=episode_id)
-                episode.contributors.add(user)
+            if agent_data.episodes:
+                for episode_id in agent_data.episodes:
+                    episode = Episode.objects.get(id=episode_id)
+                    episode.contributors.add(user)

--- a/backend/person/mutations/CreateAgentMutation.py
+++ b/backend/person/mutations/CreateAgentMutation.py
@@ -15,6 +15,8 @@ from graphql_app.LettercraftMutation import LettercraftMutation
 from graphql_app.types.LettercraftErrorType import LettercraftErrorType
 from django.core.exceptions import ValidationError
 from django.db import transaction
+from event.models import Episode
+from source.models import Source
 
 
 class CreateAgentInput(InputObjectType):
@@ -38,6 +40,7 @@ class CreateAgentMutation(LettercraftMutation):
         try:
             with transaction.atomic():
                 cls.mutate_object(agent_data, agent, info)
+                cls._add_contribution(agent, agent_data, info)
                 agent.full_clean()
         except ValidationError as e:
             errors = [
@@ -47,3 +50,14 @@ class CreateAgentMutation(LettercraftMutation):
             return cls(ok=False, agent=None, errors=errors)
 
         return cls(ok=True, agent=agent, errors=[])
+
+    def _add_contribution(
+        agent: AgentDescription, agent_data: CreateAgentInput, info: ResolveInfo
+    ):
+        user = info.context.user
+        agent.contributors.add(user)
+
+        if agent_data.episodes:
+            for episode_id in agent_data.episodes:
+                episode = Episode.objects.get(id=episode_id)
+                episode.contributors.add(user)

--- a/backend/person/mutations/UpdateAgentMutation.py
+++ b/backend/person/mutations/UpdateAgentMutation.py
@@ -141,5 +141,6 @@ class UpdateAgentMutation(LettercraftMutation):
     def add_contribution(
         agent: AgentDescription, agent_data: UpdateAgentInput, info: ResolveInfo
     ):
-        user = info.context.user
-        agent.contributors.add(user)
+        if info.context:
+            user = info.context.user
+            agent.contributors.add(user)

--- a/backend/person/mutations/UpdateAgentMutation.py
+++ b/backend/person/mutations/UpdateAgentMutation.py
@@ -72,6 +72,7 @@ class UpdateAgentMutation(LettercraftMutation):
                     excluded_fields=["gender", "location"],
                 )
                 cls.handle_nested_fields(agent, agent_data, info)
+                cls.add_contribution(agent, agent_data, info)
                 # refresh to load related objects if those were updated through nested
                 # fields
                 agent.refresh_from_db()
@@ -136,3 +137,9 @@ class UpdateAgentMutation(LettercraftMutation):
                 related_obj = related_model(**relation)
             cls.mutate_object(nested_data, related_obj, info)
             related_obj.full_clean()
+
+    def add_contribution(
+        agent: AgentDescription, agent_data: UpdateAgentInput, info: ResolveInfo
+    ):
+        user = info.context.user
+        agent.contributors.add(user)

--- a/backend/person/mutations/UpdateAgentMutation.py
+++ b/backend/person/mutations/UpdateAgentMutation.py
@@ -9,7 +9,7 @@ from graphene import (
     Enum,
     NonNull,
 )
-
+from typing import Union
 from person.types.AgentDescriptionType import AgentDescriptionType
 from person.models import AgentDescription, Gender
 from core.models import SourceMention
@@ -109,7 +109,7 @@ class UpdateAgentMutation(LettercraftMutation):
         agent_data: UpdateAgentInput,
         info: ResolveInfo,
         field_name: str,
-        descriptor: ForwardOneToOneDescriptor | ReverseOneToOneDescriptor,
+        descriptor: Union[ForwardOneToOneDescriptor, ReverseOneToOneDescriptor],
     ):
 
         if not field_name in agent_data:

--- a/backend/person/queries.py
+++ b/backend/person/queries.py
@@ -1,5 +1,7 @@
 from graphene import ID, Field, List, NonNull, ObjectType, ResolveInfo
 from django.db.models import QuerySet, Q
+from typing import Optional
+
 from person.models import AgentDescription
 from person.types.AgentDescriptionType import AgentDescriptionType
 
@@ -13,7 +15,7 @@ class PersonQueries(ObjectType):
     @staticmethod
     def resolve_agent_description(
         parent: None, info: ResolveInfo, id: str
-    ) -> AgentDescription | None:
+    ) -> Optional[AgentDescription]:
         try:
             return AgentDescriptionType.get_queryset(
                 AgentDescription.objects, info
@@ -25,8 +27,8 @@ class PersonQueries(ObjectType):
     def resolve_agent_descriptions(
         parent: None,
         info: ResolveInfo,
-        episode_id: str | None = None,
-        source_id: str | None = None,
+        episode_id: Optional[str] = None,
+        source_id: Optional[str] = None,
     ) -> QuerySet[AgentDescription]:
         filters = Q()
         if episode_id:

--- a/backend/source/queries.py
+++ b/backend/source/queries.py
@@ -1,5 +1,6 @@
 from graphene import ID, Field, NonNull, ObjectType, ResolveInfo
 from graphene_django import DjangoListField
+from typing import Optional
 
 from source.models import Source
 from source.types.SourceType import SourceType
@@ -10,7 +11,7 @@ class SourceQueries(ObjectType):
     sources = DjangoListField(NonNull(SourceType), required=True)
 
     @staticmethod
-    def resolve_source(root: None, info: ResolveInfo, id: str) -> Source | None:
+    def resolve_source(root: None, info: ResolveInfo, id: str) -> Optional[Source]:
         try:
             return SourceType.get_queryset(Source.objects, info).get(pk=id)
         except Source.DoesNotExist:

--- a/backend/space/queries.py
+++ b/backend/space/queries.py
@@ -1,5 +1,6 @@
 from graphene import ID, Field, List, NonNull, ObjectType, ResolveInfo
 from django.db.models import Q, QuerySet
+from typing import Optional
 
 from space.models import SpaceDescription
 from space.types.SpaceDescriptionType import SpaceDescriptionType
@@ -14,7 +15,7 @@ class SpaceQueries(ObjectType):
     @staticmethod
     def resolve_space_description(
         parent: None, info: ResolveInfo, id: str
-    ) -> SpaceDescription | None:
+    ) -> Optional[SpaceDescription]:
         try:
             return SpaceDescriptionType.get_queryset(
                 SpaceDescription.objects, info
@@ -26,7 +27,7 @@ class SpaceQueries(ObjectType):
     def resolve_space_descriptions(
         parent: None,
         info: ResolveInfo,
-        source_id: str | None = None,
+        source_id: Optional[str] = None,
     ) -> QuerySet[SpaceDescription]:
         filters = Q() if source_id is None else Q(source_id=source_id)
 

--- a/backend/user/queries.py
+++ b/backend/user/queries.py
@@ -2,6 +2,8 @@ from graphene import Field, List, ResolveInfo
 from django.db.models import QuerySet
 from graphene import ID, Field, List, NonNull, ObjectType, ResolveInfo
 from django.db.models import QuerySet
+from typing import Optional
+
 from user.types.UserType import UserType
 from user.models import User
 
@@ -13,7 +15,7 @@ class UserQueries(ObjectType):
     @staticmethod
     def resolve_user_description(
         parent: None, info: ResolveInfo, id: str
-    ) -> User | None:
+    ) -> Optional[User]:
         try:
             return UserType.get_queryset(User.objects, info).get(id=id)
         except User.DoesNotExist:

--- a/frontend/angular.json
+++ b/frontend/angular.json
@@ -47,7 +47,7 @@
                 {
                   "type": "initial",
                   "maximumWarning": "500kb",
-                  "maximumError": "1mb"
+                  "maximumError": "2mb"
                 },
                 {
                   "type": "anyComponentStyle",

--- a/frontend/generated/graphql.ts
+++ b/frontend/generated/graphql.ts
@@ -1120,7 +1120,7 @@ export type DataEntryEpisodeFormQueryVariables = Exact<{
 }>;
 
 
-export type DataEntryEpisodeFormQuery = { __typename?: 'Query', episode?: { __typename?: 'EpisodeType', id: string, name: string, description: string, source: { __typename?: 'SourceType', id: string, name: string } } | null };
+export type DataEntryEpisodeFormQuery = { __typename?: 'Query', episode?: { __typename?: 'EpisodeType', id: string, name: string, source: { __typename?: 'SourceType', id: string, name: string } } | null };
 
 export type DataEntryUpdateEpisodeMutationVariables = Exact<{
   episodeData: UpdateEpisodeInput;
@@ -1651,7 +1651,6 @@ export const DataEntryEpisodeFormDocument = gql`
   episode(id: $id) {
     id
     name
-    description
     source {
       id
       name

--- a/frontend/src/app/data-entry/agent-form/agent-episodes-form/agent-episodes-form.component.ts
+++ b/frontend/src/app/data-entry/agent-form/agent-episodes-form/agent-episodes-form.component.ts
@@ -14,6 +14,7 @@ import { actionIcons } from '@shared/icons';
 import { FormStatus } from '../../shared/types';
 import { MutationResult } from 'apollo-angular';
 import { differenceBy } from '@shared/utils';
+import { ApolloCache } from '@apollo/client/core';
 
 
 @Component({
@@ -110,7 +111,7 @@ export class AgentEpisodesFormComponent implements OnDestroy {
         this.status$.next('error');
     }
 
-    private updateCache(episodeID: string, agentID: string, cache: any) {
+    private updateCache(episodeID: string, agentID: string, cache: ApolloCache<unknown>) {
         cache.evict({ id: cache.identify({ __typename: "EpisodeType", id: episodeID }) });
         cache.evict({ id: cache.identify({ __typename: "AgentDescriptionType", id: agentID }) });
         cache.gc();

--- a/frontend/src/app/data-entry/agent-form/agent-form.component.html
+++ b/frontend/src/app/data-entry/agent-form/agent-form.component.html
@@ -3,7 +3,7 @@
 
     <ng-container *ngIf="data.agentDescription as agentDescription; else noAgent">
         <h1 class="mb-4">
-            <lc-icon [icon]="dataIcons.person" />
+            <lc-icon [icon]="agentDescription.isGroup ? dataIcons.group : dataIcons.person" />
             {{agentDescription.name}}
             <span class="text-secondary">
                 ({{agentDescription.source.name}})

--- a/frontend/src/app/data-entry/agent-form/agent-identification-form/agent-identification-form.component.spec.ts
+++ b/frontend/src/app/data-entry/agent-form/agent-identification-form/agent-identification-form.component.spec.ts
@@ -13,7 +13,6 @@ describe('AgentIdentificationFormComponent', () => {
             declarations: [AgentIdentificationFormComponent],
             providers: [FormService],
             imports: [SharedTestingModule],
-            providers: [FormService],
         });
         fixture = TestBed.createComponent(AgentIdentificationFormComponent);
         component = fixture.componentInstance;

--- a/frontend/src/app/data-entry/agent-form/agent-identification-form/agent-identification-form.component.spec.ts
+++ b/frontend/src/app/data-entry/agent-form/agent-identification-form/agent-identification-form.component.spec.ts
@@ -13,6 +13,7 @@ describe('AgentIdentificationFormComponent', () => {
             declarations: [AgentIdentificationFormComponent],
             providers: [FormService],
             imports: [SharedTestingModule],
+            providers: [FormService],
         });
         fixture = TestBed.createComponent(AgentIdentificationFormComponent);
         component = fixture.componentInstance;

--- a/frontend/src/app/data-entry/agent-form/delete-agent/delete-agent.component.html
+++ b/frontend/src/app/data-entry/agent-form/delete-agent/delete-agent.component.html
@@ -1,28 +1,4 @@
-<button class="btn btn-danger" (click)="open(confirmModal)">
+<button class="btn btn-danger" *ngIf="id$ | async as id" (click)="openConfirm(id)">
     <lc-icon [icon]="actionIcons.delete"></lc-icon>
     Delete agent
 </button>
-
-<ng-template #confirmModal let-modal>
-    <div class="modal-header">
-        <h2 class="modal-title" id="modal-title">Delete agent?</h2>
-        <button type="button" class="btn-close" aria-label="close"
-            (click)="modal.dismiss('cancel')">
-        </button>
-    </div>
-    <div class="modal-body">
-        <p>
-            Delete this agent from this source text? They will be removed from <i>all</i>
-            episodes they are involved in!
-        </p>
-    </div>
-    <div class="modal-footer">
-        <button type="button" class="btn btn-danger"
-            *ngIf="id$ | async as id" (click)="modal.close(id)">
-            Delete
-        </button>
-        <button type="button" class="btn btn-secondary" (click)="modal.dismiss('cancel')">
-            Cancel
-        </button>
-    </div>
-</ng-template>

--- a/frontend/src/app/data-entry/episode-form/episode-contents-form/episode-contents-form.component.spec.ts
+++ b/frontend/src/app/data-entry/episode-form/episode-contents-form/episode-contents-form.component.spec.ts
@@ -2,6 +2,7 @@ import { ComponentFixture, TestBed } from "@angular/core/testing";
 
 import { EpisodeContentsFormComponent } from "./episode-contents-form.component";
 import { SharedTestingModule } from "@shared/shared-testing.module";
+import { FormService } from "../../shared/form.service";
 
 describe("EpisodeContentsFormComponent", () => {
     let component: EpisodeContentsFormComponent;
@@ -11,6 +12,7 @@ describe("EpisodeContentsFormComponent", () => {
         TestBed.configureTestingModule({
             declarations: [EpisodeContentsFormComponent],
             imports: [SharedTestingModule],
+            providers: [FormService],
         });
         fixture = TestBed.createComponent(EpisodeContentsFormComponent);
         component = fixture.componentInstance;

--- a/frontend/src/app/data-entry/episode-form/episode-contents-form/episode-contents-form.component.ts
+++ b/frontend/src/app/data-entry/episode-form/episode-contents-form/episode-contents-form.component.ts
@@ -92,15 +92,7 @@ export class EpisodeContentsFormComponent implements OnInit {
                         filter(() => this.form.valid),
                         debounceTime(300),
                         withLatestFrom(this.id$),
-                        switchMap(([episode, id]) =>
-                            this.updateEpisode
-                                .mutate({
-                                    episodeData: {
-                                        id,
-                                        ...episode,
-                                    },
-                                })
-                        )
+                        switchMap(this.makeMutation.bind(this))
                     )
                 )
             )
@@ -114,5 +106,23 @@ export class EpisodeContentsFormComponent implements OnInit {
                     });
                 }
             });
+    }
+
+    private makeMutation([episode, id]: [typeof this.form.value, string]) {
+        return this.updateEpisode.mutate({
+            episodeData: {
+                id,
+                ...episode,
+            },
+        }, {
+            update: (cache) => {
+                const identified = cache.identify({
+                    __typename: "EpisodeType",
+                    id,
+                });
+                cache.evict({ id: identified });
+                cache.gc();
+            },
+        });
     }
 }

--- a/frontend/src/app/data-entry/episode-form/episode-contents-form/episode-contents-form.component.ts
+++ b/frontend/src/app/data-entry/episode-form/episode-contents-form/episode-contents-form.component.ts
@@ -1,12 +1,12 @@
-import { Component, DestroyRef, OnInit } from "@angular/core";
+import { Component, DestroyRef, OnDestroy, OnInit } from "@angular/core";
 import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import { FormControl, FormGroup } from "@angular/forms";
-import { ActivatedRoute } from "@angular/router";
 import { ToastService } from "@services/toast.service";
 import {
     DataEntryEpisodeCategoriesGQL,
     DataEntryEpisodeContentsGQL,
     DataEntryUpdateEpisodeGQL,
+    DataEntryUpdateEpisodeMutation,
 } from "generated/graphql";
 import {
     debounceTime,
@@ -15,19 +15,21 @@ import {
     Observable,
     shareReplay,
     switchMap,
-    withLatestFrom,
+    tap,
+    withLatestFrom
 } from "rxjs";
 import { LabelSelectOption } from "../../shared/label-select/label-select.component";
+import { FormService } from "../../shared/form.service";
+import { formStatusSubject } from "../../shared/utils";
+import { MutationResult } from "apollo-angular";
 
 @Component({
     selector: "lc-episode-contents-form",
     templateUrl: "./episode-contents-form.component.html",
     styleUrls: ["./episode-contents-form.component.scss"],
 })
-export class EpisodeContentsFormComponent implements OnInit {
-    private id$: Observable<string> = this.route.params.pipe(
-        map((params) => params["id"])
-    );
+export class EpisodeContentsFormComponent implements OnInit, OnDestroy {
+    private id$: Observable<string> = this.formService.id$;
 
     private episode$ = this.id$.pipe(
         switchMap((id) => this.episodeQuery.watch({ id }).valueChanges),
@@ -56,14 +58,18 @@ export class EpisodeContentsFormComponent implements OnInit {
             })
         );
 
+    private status$ = formStatusSubject();
+
     constructor(
         private destroyRef: DestroyRef,
-        private route: ActivatedRoute,
+        private formService: FormService,
         private toastService: ToastService,
         private episodeQuery: DataEntryEpisodeContentsGQL,
         private episodeCategoriesQuery: DataEntryEpisodeCategoriesGQL,
         private updateEpisode: DataEntryUpdateEpisodeGQL
-    ) {}
+    ) {
+        this.formService.attachForm('contents', this.status$);
+    }
 
     ngOnInit(): void {
         this.episode$
@@ -86,26 +92,20 @@ export class EpisodeContentsFormComponent implements OnInit {
 
         this.episode$
             .pipe(
-                switchMap(() =>
-                    this.form.valueChanges.pipe(
-                        map(() => this.form.getRawValue()),
-                        filter(() => this.form.valid),
-                        debounceTime(300),
-                        withLatestFrom(this.id$),
-                        switchMap(this.makeMutation.bind(this))
-                    )
-                )
+                switchMap(() => this.form.valueChanges),
+                map(() => this.form.getRawValue()),
+                filter(() => this.form.valid),
+                debounceTime(300),
+                tap(() => this.status$.next('loading')),
+                withLatestFrom(this.id$),
+                switchMap(this.makeMutation.bind(this))
             )
-            .subscribe((result) => {
-                const errors = result.data?.updateEpisode?.errors;
-                if (errors && errors.length > 0) {
-                    this.toastService.show({
-                        body: errors.map((error) => error.messages).join("\n"),
-                        type: "danger",
-                        header: "Update failed",
-                    });
-                }
-            });
+            .subscribe(this.handleResult.bind(this));
+    }
+
+    ngOnDestroy(): void {
+        this.formService.detachForm('contents');
+        this.status$.complete();
     }
 
     private makeMutation([episode, id]: [typeof this.form.value, string]) {
@@ -124,5 +124,19 @@ export class EpisodeContentsFormComponent implements OnInit {
                 cache.gc();
             },
         });
+    }
+
+    private handleResult(result: MutationResult<DataEntryUpdateEpisodeMutation>) {
+        const errors = result.data?.updateEpisode?.errors;
+        if (errors && errors.length > 0) {
+            this.status$.next('error');
+            this.toastService.show({
+                body: errors.map((error) => error.messages).join("\n"),
+                type: "danger",
+                header: "Update failed",
+            });
+        } else {
+            this.status$.next('saved');
+        }
     }
 }

--- a/frontend/src/app/data-entry/episode-form/episode-entities-form/episode-entities-form.component.ts
+++ b/frontend/src/app/data-entry/episode-form/episode-entities-form/episode-entities-form.component.ts
@@ -15,6 +15,7 @@ import {
 } from "generated/graphql";
 import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import { splat, differenceBy } from "@shared/utils";
+import { ToastService } from "@services/toast.service";
 
 type EntityPropertyName = 'agents' | 'gifts' | 'letters' | 'spaces';
 
@@ -51,6 +52,7 @@ export class EpisodeEntitiesFormComponent implements OnChanges, OnDestroy {
         private query: DataEntryEpisodeEntitiesGQL,
         private addMutation: DataEntryCreateEpisodeEntityLinkGQL,
         private removeMutation: DataEntryDeleteEpisodeEntityLinkGQL,
+        private toastService: ToastService,
     ) {
         this.data$ = this.formService.id$.pipe(
             switchMap(id => this.query.watch({ id }).valueChanges),
@@ -139,6 +141,11 @@ export class EpisodeEntitiesFormComponent implements OnChanges, OnDestroy {
 
     onError(error: any) {
         console.error(error);
+        this.toastService.show({
+            header: 'Creating agent failed',
+            body: 'Could not create agent',
+            type: 'danger',
+        })
         this.status$.next('error');
     }
 

--- a/frontend/src/app/data-entry/episode-form/episode-entities-form/episode-entities-form.component.ts
+++ b/frontend/src/app/data-entry/episode-form/episode-entities-form/episode-entities-form.component.ts
@@ -16,6 +16,7 @@ import {
 import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import { splat, differenceBy } from "@shared/utils";
 import { ToastService } from "@services/toast.service";
+import { ApolloCache } from "@apollo/client/core";
 
 type EntityPropertyName = 'agents' | 'gifts' | 'letters' | 'spaces';
 type EntityTypeName = 'AgentDescriptionType' | 'GiftDescriptionType' | 'LetterDescriptionType' | 'SpaceDescriptionType';
@@ -177,15 +178,21 @@ export class EpisodeEntitiesFormComponent implements OnChanges, OnDestroy {
         return differenceBy(allEntities, linkedEntities, 'id');
     }
 
-    private updateCacheOnAddRemove(episodeID: string, entityID: string, cache: any) {
-        cache.evict(cache.identify({
-            __typename: "EpisodeType",
-            id: episodeID,
-        }));
-        cache.evict(cache.identify({
-            __typename: this.entityTypeName,
-            id: entityID,
-        }));
+    private updateCacheOnAddRemove(episodeID: string, entityID: string, cache: ApolloCache<unknown>) {
+        cache.evict({
+            id: cache.identify({
+                __typename: "EpisodeType",
+                id: episodeID,
+            }),
+            fieldName: this.entityProperty,
+        });
+        cache.evict({
+            id: cache.identify({
+                __typename: this.entityTypeName,
+                id: entityID,
+            }),
+            fieldName: 'episodes',
+        });
         cache.gc();
     }
 

--- a/frontend/src/app/data-entry/episode-form/episode-entities-form/episode-entities-form.component.ts
+++ b/frontend/src/app/data-entry/episode-form/episode-entities-form/episode-entities-form.component.ts
@@ -144,8 +144,8 @@ export class EpisodeEntitiesFormComponent implements OnChanges, OnDestroy {
     onError(error: any) {
         console.error(error);
         this.toastService.show({
-            header: 'Creating agent failed',
-            body: 'Could not create agent',
+            header: `Adding ${this.entityName} failed`,
+            body: `Could not add ${this.entityName}`,
             type: 'danger',
         })
         this.status$.next('error');

--- a/frontend/src/app/data-entry/episode-form/episode-entities-form/episode-entities-form.component.ts
+++ b/frontend/src/app/data-entry/episode-form/episode-entities-form/episode-entities-form.component.ts
@@ -18,8 +18,7 @@ import { splat, differenceBy } from "@shared/utils";
 import { ToastService } from "@services/toast.service";
 
 type EntityPropertyName = 'agents' | 'gifts' | 'letters' | 'spaces';
-
-const REFETCH_QUERIES = ['DataEntryEpisodeEntities'];
+type EntityTypeName = 'AgentDescriptionType' | 'GiftDescriptionType' | 'LetterDescriptionType' | 'SpaceDescriptionType';
 
 let nextID = 0;
 
@@ -95,6 +94,16 @@ export class EpisodeEntitiesFormComponent implements OnChanges, OnDestroy {
             [Entity.Space]: 'spaces',
         }
         return keys[this.entityType]
+    }
+
+    get entityTypeName(): EntityTypeName {
+        const types: Record<Entity, EntityTypeName> = {
+            [Entity.Agent]: 'AgentDescriptionType',
+            [Entity.Gift]: 'GiftDescriptionType',
+            [Entity.Letter]: 'LetterDescriptionType',
+            [Entity.Space]: 'SpaceDescriptionType',
+        }
+        return types[this.entityType];
     }
 
     ngOnChanges(changes: SimpleChanges): void {
@@ -173,7 +182,7 @@ export class EpisodeEntitiesFormComponent implements OnChanges, OnDestroy {
             id: episodeID,
         }));
         cache.evict(cache.identify({
-            __typename: "AgentDescriptionType",
+            __typename: this.entityTypeName,
             id: entityID,
         }));
         cache.gc();

--- a/frontend/src/app/data-entry/episode-form/episode-entities-form/episode-entities-form.component.ts
+++ b/frontend/src/app/data-entry/episode-form/episode-entities-form/episode-entities-form.component.ts
@@ -118,7 +118,7 @@ export class EpisodeEntitiesFormComponent implements OnChanges, OnDestroy {
             entityType: this.entityType,
         };
         this.addMutation.mutate({ input }, {
-            refetchQueries: REFETCH_QUERIES,
+            update: cache => this.updateCacheOnAddRemove(episodeID, entityID, cache),
         }).pipe(
             tap(() => this.status$.next('loading'))
         ).subscribe(this.mutationObserver);
@@ -130,7 +130,9 @@ export class EpisodeEntitiesFormComponent implements OnChanges, OnDestroy {
             episode: episodeID,
             entityType: this.entityType,
         };
-        this.removeMutation.mutate(data, { refetchQueries: REFETCH_QUERIES }).pipe(
+        this.removeMutation.mutate(data, {
+            update: cache => this.updateCacheOnAddRemove(episodeID, entityID, cache)
+        }).pipe(
             tap(() => this.status$.next('loading'))
         ).subscribe(this.mutationObserver)
     }
@@ -164,4 +166,17 @@ export class EpisodeEntitiesFormComponent implements OnChanges, OnDestroy {
         const linkedEntities = data.episode?.[this.entityProperty] || [];
         return differenceBy(allEntities, linkedEntities, 'id');
     }
+
+    private updateCacheOnAddRemove(episodeID: string, entityID: string, cache: any) {
+        cache.evict(cache.identify({
+            __typename: "EpisodeType",
+            id: episodeID,
+        }));
+        cache.evict(cache.identify({
+            __typename: "AgentDescriptionType",
+            id: entityID,
+        }));
+        cache.gc();
+    }
+
 }

--- a/frontend/src/app/data-entry/episode-form/episode-form.component.html
+++ b/frontend/src/app/data-entry/episode-form/episode-form.component.html
@@ -8,6 +8,8 @@
     </h1>
 </ng-container>
 
+<lc-form-status [status$]="status$" />
+
 <h2 class="subform-header">Identification</h2>
 <lc-episode-identification-form />
 

--- a/frontend/src/app/data-entry/episode-form/episode-form.component.html
+++ b/frontend/src/app/data-entry/episode-form/episode-form.component.html
@@ -6,9 +6,6 @@
         <span class="ms-2">{{ episode.name }}</span>
         <span class="text-body-secondary"> ({{ episode.source.name }}) </span>
     </h1>
-    <p class="lead mb-4" *ngIf="episode.description">
-        {{ episode.description}}
-    </p>
 </ng-container>
 
 <h2 class="subform-header">Identification</h2>

--- a/frontend/src/app/data-entry/episode-form/episode-form.component.ts
+++ b/frontend/src/app/data-entry/episode-form/episode-form.component.ts
@@ -14,7 +14,7 @@ import { FormService } from "../shared/form.service";
 export class EpisodeFormComponent {
     Entity = Entity;
 
-    private id$ = this.route.params.pipe(map((params) => params["id"]));
+    private id$ = this.formService.id$;
 
     public episode$ = this.id$.pipe(
         switchMap((id) => this.episodeQuery.watch({ id }).valueChanges),
@@ -49,11 +49,14 @@ export class EpisodeFormComponent {
         })
     );
 
+    status$ = this.formService.status$;
+
     public dataIcons = dataIcons;
     public actionIcons = actionIcons;
 
     constructor(
         private route: ActivatedRoute,
-        private episodeQuery: DataEntryEpisodeFormGQL
+        private episodeQuery: DataEntryEpisodeFormGQL,
+        private formService: FormService,
     ) {}
 }

--- a/frontend/src/app/data-entry/episode-form/episode-identification-form/episode-identification-form.component.html
+++ b/frontend/src/app/data-entry/episode-form/episode-identification-form/episode-identification-form.component.html
@@ -17,16 +17,4 @@
         />
         <p class="invalid-feedback">This field is required.</p>
     </div>
-
-    <div class="form-group mt-4">
-        <label for="episode-description" class="form-label">Description</label>
-        <p class="form-text">
-            A longer description to help identify this object in the database.
-        </p>
-        <textarea
-            id="episode-description"
-            class="form-control"
-            [formControl]="form.controls.description"
-        ></textarea>
-    </div>
 </form>

--- a/frontend/src/app/data-entry/episode-form/episode-identification-form/episode-identification-form.component.spec.ts
+++ b/frontend/src/app/data-entry/episode-form/episode-identification-form/episode-identification-form.component.spec.ts
@@ -2,6 +2,7 @@ import { ComponentFixture, TestBed } from "@angular/core/testing";
 
 import { EpisodeIdentificationFormComponent } from "./episode-identification-form.component";
 import { SharedTestingModule } from "@shared/shared-testing.module";
+import { FormService } from "../../shared/form.service";
 
 describe("EpisodeIdentificationFormComponent", () => {
     let component: EpisodeIdentificationFormComponent;
@@ -11,6 +12,7 @@ describe("EpisodeIdentificationFormComponent", () => {
         TestBed.configureTestingModule({
             declarations: [EpisodeIdentificationFormComponent],
             imports: [SharedTestingModule],
+            providers: [FormService],
         });
         fixture = TestBed.createComponent(EpisodeIdentificationFormComponent);
         component = fixture.componentInstance;

--- a/frontend/src/app/data-entry/episode-form/episode-identification-form/episode-identification-form.component.ts
+++ b/frontend/src/app/data-entry/episode-form/episode-identification-form/episode-identification-form.component.ts
@@ -2,7 +2,6 @@ import { Component, DestroyRef, OnInit } from "@angular/core";
 import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import { FormControl, FormGroup, Validators } from "@angular/forms";
 import { ActivatedRoute } from "@angular/router";
-import { ApolloCache } from "@apollo/client/core";
 import { ToastService } from "@services/toast.service";
 import { MutationResult } from "apollo-angular";
 import {
@@ -49,9 +48,6 @@ export class EpisodeIdentificationFormComponent implements OnInit {
         name: new FormControl<string>("", {
             nonNullable: true,
             validators: [Validators.required],
-        }),
-        description: new FormControl<string>("", {
-            nonNullable: true,
         }),
     });
 
@@ -120,7 +116,7 @@ export class EpisodeIdentificationFormComponent implements OnInit {
         );
     }
 
-    private updateCache(cache: ApolloCache<unknown>, id: string): void {
+    private updateCache(cache: any, id: string): void {
         const identified = cache.identify({
             __typename: "EpisodeType",
             id,

--- a/frontend/src/app/data-entry/episode-form/episode-identification-form/episode-identification-form.component.ts
+++ b/frontend/src/app/data-entry/episode-form/episode-identification-form/episode-identification-form.component.ts
@@ -20,6 +20,8 @@ import {
 } from "rxjs";
 import { FormService } from "../../shared/form.service";
 import { formStatusSubject } from "../../shared/utils";
+import { ApolloCache } from "@apollo/client/core";
+
 
 interface EpisodeIdentification {
     name: string;
@@ -116,12 +118,12 @@ export class EpisodeIdentificationFormComponent implements OnDestroy {
         );
     }
 
-    private updateCache(cache: any, id: string): void {
+    private updateCache(cache: ApolloCache<unknown>, id: string): void {
         const identified = cache.identify({
             __typename: "EpisodeType",
             id,
         });
-        cache.evict({ id: identified });
+        cache.evict({ id: identified, fieldName: 'name' });
         cache.gc();
     }
 

--- a/frontend/src/app/data-entry/episode-form/episode-source-text-form/episode-source-text-form.component.spec.ts
+++ b/frontend/src/app/data-entry/episode-form/episode-source-text-form/episode-source-text-form.component.spec.ts
@@ -2,6 +2,7 @@ import { ComponentFixture, TestBed } from "@angular/core/testing";
 
 import { EpisodeSourceTextFormComponent } from "./episode-source-text-form.component";
 import { SharedTestingModule } from "@shared/shared-testing.module";
+import { FormService } from "../../shared/form.service";
 
 describe("EpisodeSourceTextFormComponent", () => {
     let component: EpisodeSourceTextFormComponent;
@@ -11,6 +12,7 @@ describe("EpisodeSourceTextFormComponent", () => {
         TestBed.configureTestingModule({
             declarations: [EpisodeSourceTextFormComponent],
             imports: [SharedTestingModule],
+            providers: [FormService],
         });
         fixture = TestBed.createComponent(EpisodeSourceTextFormComponent);
         component = fixture.componentInstance;

--- a/frontend/src/app/data-entry/episode-form/episode-source-text-form/episode-source-text-form.component.ts
+++ b/frontend/src/app/data-entry/episode-form/episode-source-text-form/episode-source-text-form.component.ts
@@ -1,4 +1,4 @@
-import { Component, DestroyRef, OnInit } from "@angular/core";
+import { Component, DestroyRef, OnDestroy, OnInit } from "@angular/core";
 import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import { FormControl, FormGroup } from "@angular/forms";
 import { ActivatedRoute } from "@angular/router";
@@ -6,6 +6,7 @@ import { ToastService } from "@services/toast.service";
 import {
     DataEntryEpisodeSourceTextMentionGQL,
     DataEntryUpdateEpisodeGQL,
+    DataEntryUpdateEpisodeMutation,
 } from "generated/graphql";
 import {
     debounceTime,
@@ -14,15 +15,19 @@ import {
     Observable,
     shareReplay,
     switchMap,
+    tap,
     withLatestFrom,
 } from "rxjs";
+import { FormService } from "../../shared/form.service";
+import { formStatusSubject } from "../../shared/utils";
+import { MutationResult } from "apollo-angular";
 
 @Component({
     selector: "lc-episode-source-text-form",
     templateUrl: "./episode-source-text-form.component.html",
     styleUrls: ["./episode-source-text-form.component.scss"],
 })
-export class EpisodeSourceTextFormComponent implements OnInit {
+export class EpisodeSourceTextFormComponent implements OnInit, OnDestroy {
     private id$: Observable<string> = this.route.params.pipe(
         map((params) => params["id"])
     );
@@ -40,13 +45,18 @@ export class EpisodeSourceTextFormComponent implements OnInit {
         page: new FormControl<string>("", { nonNullable: true }),
     });
 
+    private status$ = formStatusSubject();
+
     constructor(
         private destroyRef: DestroyRef,
         private route: ActivatedRoute,
         private toastService: ToastService,
         private episodeQuery: DataEntryEpisodeSourceTextMentionGQL,
-        private updateEpisode: DataEntryUpdateEpisodeGQL
-    ) {}
+        private updateEpisode: DataEntryUpdateEpisodeGQL,
+        private formService: FormService,
+    ) {
+        this.formService.attachForm('source-text', this.status$);
+    }
 
     ngOnInit(): void {
         this.episode$
@@ -63,33 +73,40 @@ export class EpisodeSourceTextFormComponent implements OnInit {
 
         this.episode$
             .pipe(
-                switchMap(() =>
-                    this.form.valueChanges.pipe(
-                        map(() => this.form.getRawValue()),
-                        filter(() => this.form.valid),
-                        debounceTime(300),
-                        withLatestFrom(this.id$),
-                        switchMap(([episode, id]) =>
-                            this.updateEpisode.mutate({
-                                episodeData: {
-                                    id,
-                                    ...episode,
-                                },
-                            })
-                        ),
-                        takeUntilDestroyed(this.destroyRef)
-                    )
-                )
-            )
-            .subscribe((result) => {
-                const errors = result.data?.updateEpisode?.errors;
-                if (errors && errors.length > 0) {
-                    this.toastService.show({
-                        body: errors.map((error) => error.messages).join("\n"),
-                        type: "danger",
-                        header: "Update failed",
-                    });
-                }
+                switchMap(() => this.form.valueChanges),
+                map(() => this.form.getRawValue()),
+                filter(() => this.form.valid),
+                debounceTime(300),
+                withLatestFrom(this.id$),
+                tap(() => this.status$.next('loading')),
+                switchMap(([episode, id]) =>
+                    this.updateEpisode.mutate({
+                        episodeData: {
+                            id,
+                            ...episode,
+                        },
+                    })
+                ),
+                takeUntilDestroyed(this.destroyRef)
+        )
+            .subscribe(this.handleResult.bind(this));
+    }
+
+    ngOnDestroy(): void {
+        this.formService.detachForm('source-text');
+    }
+
+    private handleResult(result: MutationResult<DataEntryUpdateEpisodeMutation>) {
+        const errors = result.data?.updateEpisode?.errors;
+        if (errors && errors.length > 0) {
+            this.status$.next('error');
+            this.toastService.show({
+                body: errors.map((error) => error.messages).join("\n"),
+                type: "danger",
+                header: "Update failed",
             });
+        } else {
+            this.status$.next('saved');
+        }
     }
 }

--- a/frontend/src/app/data-entry/episode-form/episode.graphql
+++ b/frontend/src/app/data-entry/episode-form/episode.graphql
@@ -2,7 +2,6 @@ query DataEntryEpisodeForm($id: ID!) {
     episode(id: $id) {
         id
         name
-        description
         source {
             id
             name

--- a/frontend/src/app/data-entry/shared/designators-control/designators-control.component.html
+++ b/frontend/src/app/data-entry/shared/designators-control/designators-control.component.html
@@ -10,7 +10,7 @@
         <li *ngFor="let designator of designators$.value; let i = index"
             class="list-group-item hstack gap-3">
             <span>{{designator}}</span>
-            <button class="btn ms-auto" type="button"
+            <button class="btn btn-light ms-auto" type="button"
                 [disabled]="disabled"
                 (blur)="blur$.next()"
                 (click)="removeDesignator(i)">
@@ -30,7 +30,7 @@
         <button class="btn btn-primary" type="submit"
             [disabled]="disabled"
             (blur)="blur$.next()">
-            <lc-icon [icon]="actionIcons.add" aria-label="add designator" />
+            <lc-icon [icon]="actionIcons.add" aria-label="add provided designator" />
         </button>
     </div>
 </form>

--- a/frontend/src/app/data-entry/source/episode-preview/episode-preview.component.html
+++ b/frontend/src/app/data-entry/source/episode-preview/episode-preview.component.html
@@ -19,7 +19,10 @@
         </div>
     </div>
     <div class="card-body">
-        <p>{{ episode.summary || "..." }}</p>
+        <p>
+            <span *ngIf="episode.summary; else noDescription">{{episode.summary}}</span>
+            <ng-template #noDescription><i>(No description added.)</i></ng-template>
+        </p>
 
         <dl>
             <dt>Agents</dt>
@@ -40,7 +43,7 @@
                 </ul>
             </dd>
             <ng-template #noAgents>
-                <dd class="ms-4">No agents have been added yet.</dd>
+                <dd class="ms-4">No agents have been added.</dd>
             </ng-template>
 
             <dt>Locations</dt>
@@ -61,7 +64,7 @@
                 </ul>
             </dd>
             <ng-template #noSpaces>
-                <dd class="ms-4">No locations have been added yet.</dd>
+                <dd class="ms-4">No locations have been added.</dd>
             </ng-template>
 
             <dt>Objects</dt>
@@ -100,7 +103,7 @@
                 </ul>
             </dd>
             <ng-template #noObjects>
-                <dd class="ms-4">No objects have been added yet.</dd>
+                <dd class="ms-4">No objects have been added.</dd>
             </ng-template>
         </dl>
         <div class="d-flex justify-content-end">

--- a/frontend/src/app/data-entry/source/episode-preview/episode-preview.component.html
+++ b/frontend/src/app/data-entry/source/episode-preview/episode-preview.component.html
@@ -6,9 +6,10 @@
                 &nbsp;
                 {{ episode.name }}
                 <br />
-                <small *ngIf="episode.book || episode.chapter" class="inline-list">
+                <small *ngIf="episode.book || episode.chapter || episode.page" class="inline-list">
                     <span *ngIf="episode.book" class="inline-list-item">book {{ episode.book }}</span>
                     <span *ngIf="episode.chapter" class="inline-list-item">chapter {{ episode.chapter }}</span>
+                    <span *ngIf="episode.page" class="inline-list-item">page {{ episode.page }}</span>
                 </small>
             </div>
             <lc-action-button-group

--- a/frontend/src/app/data-entry/source/episode-preview/episode-preview.component.html
+++ b/frontend/src/app/data-entry/source/episode-preview/episode-preview.component.html
@@ -20,8 +20,8 @@
     </div>
     <div class="card-body">
         <p>
-            <span *ngIf="episode.summary; else noDescription">{{episode.summary}}</span>
-            <ng-template #noDescription><i>(No description added.)</i></ng-template>
+            <span *ngIf="episode.summary; else noSummary">{{episode.summary}}</span>
+            <ng-template #noSummary><i>(No summary added.)</i></ng-template>
         </p>
 
         <dl>

--- a/frontend/src/app/services/modal.service.ts
+++ b/frontend/src/app/services/modal.service.ts
@@ -13,7 +13,7 @@ interface ConfirmationModalConfig {
 export class ModalService {
     constructor(private modal: NgbModal) {}
 
-    public openConfirmationModal(config: ConfirmationModalConfig): Promise<void> {
+    public openConfirmationModal(config: ConfirmationModalConfig): Promise<any> {
         const modal = this.modal.open(ConfirmationModalComponent);
         const { title, message } = config;
         modal.componentInstance.title = title;


### PR DESCRIPTION
This include a bunch of small fixes and improvements I made when getting the application ready for deployment.

Changes:
- Some of the text in the episode preview is cleared up, e.g. "no letters added yet" -> "no letters added" (as the episode may not have any letters).
- There was a confusing overlap between the "description" and "summary" fields for episodes. I removed descriptions from the form.
- Episode previews also display the page, instead of just book/chapter.
- Added proper cache update function to several mutations in the frontend.
- Show proper status updates in the episode form.
- Fixed some compatability issues for Python 3.9 (the version used on the server), and changed the Python version in the test workflow to 3.9.
- Added contributors in some mutations that were missing that.
- Use the "group" instead of "person" icon in the header of the agent form when appropriate.
- Increased the budget for building the frontend.
- Added an alert when the mutations for adding/removing entities fail.