### PR TITLE
Fix: confirm email flow

### DIFF
--- a/frontend/src/app/services/auth.service.ts
+++ b/frontend/src/app/services/auth.service.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@angular/core';
 import { takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
 import { SessionService } from './session.service';
 import { catchError, map, of, switchMap, merge, share, startWith, withLatestFrom, shareReplay } from 'rxjs';
-import { UserRegistration, UserResponse, UserLogin, PasswordForgotten, ResetPassword, KeyInfo, UserSettings } from '../user/models/user';
+import { UserRegistration, UserResponse, UserLogin, PasswordForgotten, ResetPassword, KeyInfo, UserSettings, KeyInfoResult } from '../user/models/user';
 import { encodeUserData, parseUserData } from '../user/utils';
 import _ from 'underscore';
 import { HttpClient } from '@angular/common/http';
@@ -32,7 +32,7 @@ export class AuthService {
         this.authRoute('password/reset/confirm/'),
         'post'
     );
-    public verifyEmail = this.createRequest<string, AuthAPIResult>(
+    public verifyEmail = this.createRequest<KeyInfo, AuthAPIResult>(
         this.authRoute('registration/verify-email/'),
         'post'
     );
@@ -40,7 +40,7 @@ export class AuthService {
         this.authRoute('user/'),
         'patch'
     );
-    public keyInfo = this.createRequest<string, KeyInfo>(
+    public keyInfo = this.createRequest<KeyInfo, KeyInfoResult>(
         this.authRoute('registration/key-info/'),
         'post'
     )

--- a/frontend/src/app/user/models/user.ts
+++ b/frontend/src/app/user/models/user.ts
@@ -14,8 +14,8 @@ export class User {
         public email: string,
         public firstName: string,
         public lastName: string,
-        public isStaff: boolean,
-    ) { }
+        public isStaff: boolean
+    ) {}
 }
 
 export interface UserRegistration {
@@ -41,9 +41,13 @@ export interface PasswordForgotten {
     email: string;
 }
 
-export interface KeyInfo {
+export interface KeyInfoResult {
     username: string;
     email: string;
+}
+
+export interface KeyInfo {
+    key: string;
 }
 
 // Dj-rest-auth does not let you update your email address, but we need it to request the password reset form.

--- a/frontend/src/app/user/verify-email/verify-email.component.ts
+++ b/frontend/src/app/user/verify-email/verify-email.component.ts
@@ -1,9 +1,10 @@
 import { AfterViewInit, Component, DestroyRef, OnInit } from "@angular/core";
 import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
-import { ActivatedRoute } from "@angular/router";
+import { ActivatedRoute, Router } from "@angular/router";
 import { AuthService } from "@services/auth.service";
 import { ToastService } from "@services/toast.service";
-import { map, merge, share, startWith } from "rxjs";
+import { map, share } from "rxjs";
+import { KeyInfo } from "../models/user";
 
 @Component({
     selector: "lc-verify-email",
@@ -11,7 +12,7 @@ import { map, merge, share, startWith } from "rxjs";
     styleUrls: ["./verify-email.component.scss"],
 })
 export class VerifyEmailComponent implements OnInit, AfterViewInit {
-    private key = this.activatedRoute.snapshot.params["key"];
+    private key: KeyInfo = { key: this.activatedRoute.snapshot.params["key"] };
 
     public userDetails$ = this.authService.keyInfo.result$.pipe(
         map((results) => ("error" in results ? null : results)),
@@ -22,6 +23,7 @@ export class VerifyEmailComponent implements OnInit, AfterViewInit {
 
     constructor(
         private activatedRoute: ActivatedRoute,
+        private router: Router,
         private authService: AuthService,
         private toastService: ToastService,
         private destroyRef: DestroyRef,
@@ -51,11 +53,14 @@ export class VerifyEmailComponent implements OnInit, AfterViewInit {
 
         this.authService.verifyEmail.success$
             .pipe(takeUntilDestroyed(this.destroyRef))
-            .subscribe(() => this.toastService.show({
-                header: "Email verified",
-                body: "Email address has been verified.",
-                type: "success",
-            }));
+            .subscribe(() => {
+                this.toastService.show({
+                    header: "Email verified",
+                    body: "Email address has been verified.",
+                    type: "success",
+                });
+                this.router.navigate(['/']);
+            });
     }
 
     // We are subscribing to results of this call in the template, so we should


### PR DESCRIPTION
This PR fixes the email confirmation flow. It turned out the views handling this require the unique key to be provided in `{ key: <user-key> }` format.