### PR TITLE
Feature: delete user

### DIFF
--- a/backend/lettercraft/settings.py
+++ b/backend/lettercraft/settings.py
@@ -164,6 +164,10 @@ REST_AUTH = {
     "USER_DETAILS_SERIALIZER": "user.serializers.CustomUserDetailsSerializer",
 }
 
+# Explicitly sets the auto field to the Django 3.2+ default,
+# cf. https://docs.djangoproject.com/en/4.2/releases/3.2/#customizing-type-of-auto-created-primary-keys
+# Silences warnings from django-allauth.
+DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 
 # Internationalization
 # https://docs.djangoproject.com/en/3.0/topics/i18n/

--- a/backend/lettercraft/settings.py
+++ b/backend/lettercraft/settings.py
@@ -164,10 +164,6 @@ REST_AUTH = {
     "USER_DETAILS_SERIALIZER": "user.serializers.CustomUserDetailsSerializer",
 }
 
-# Explicitly sets the auto field to the Django 3.2+ default,
-# cf. https://docs.djangoproject.com/en/4.2/releases/3.2/#customizing-type-of-auto-created-primary-keys
-# Silences warnings from django-allauth.
-DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 
 # Internationalization
 # https://docs.djangoproject.com/en/3.0/topics/i18n/

--- a/backend/lettercraft/settings.py
+++ b/backend/lettercraft/settings.py
@@ -43,6 +43,9 @@ INSTALLED_APPS = [
     "dj_rest_auth.registration",
     "allauth",
     "allauth.account",
+    # Required for deleting accounts, but not actually used,
+    # cf. https://github.com/iMerica/dj-rest-auth/pull/110.
+    "allauth.socialaccount",
     "revproxy",
     "core",
     "case_study",

--- a/backend/user/views.py
+++ b/backend/user/views.py
@@ -1,9 +1,10 @@
 from allauth.account.models import EmailConfirmationHMAC
 from django.http import HttpRequest, HttpResponseRedirect
+from django.contrib.auth import logout
 from rest_framework.exceptions import APIException
 from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
-from rest_framework.status import HTTP_404_NOT_FOUND
+from rest_framework.status import HTTP_404_NOT_FOUND, HTTP_200_OK, HTTP_401_UNAUTHORIZED
 from rest_framework.views import APIView
 from rest_framework.viewsets import ModelViewSet
 from rest_framework.permissions import IsAuthenticated
@@ -43,10 +44,18 @@ class KeyInfoView(APIView):
         except Exception as e:
             raise APIException(e)
 
+
 class DeleteUser(APIView):
+    permission_classes = [IsAuthenticated]
+
     def delete(self, request: HttpRequest):
         user = request.user
+        if user.is_anonymous:
+            return Response({"detail": "not authenticated"}, status=HTTP_401_UNAUTHORIZED)
+        logout(request)
         user.delete()
+        return Response({"detail": "ok"}, status=HTTP_200_OK)
+
 
 class UserViewSet(ModelViewSet):
     permission_classes = [IsAuthenticated]

--- a/frontend/src/app/services/auth.service.ts
+++ b/frontend/src/app/services/auth.service.ts
@@ -72,7 +72,8 @@ export class AuthService {
 
     public currentUser$ = merge(
         this.login.subject.pipe(map(() => undefined)),
-        this.logout.result$.pipe(map(() => null)),
+        this.logout.success$.pipe(map(() => null)),
+        this.deleteUser.success$.pipe(map(() => null)),
         this.backendUser$,
         this.updateSettingsUser$
     ).pipe(


### PR DESCRIPTION
Closes #66.

This PR allows users to delete their own accounts (in the user settings menu). A pop-up is shown to confirm before deletion actually takes place.

Strangely, user deletion with `django-allauth` does not work without the `socialaccount` app installed, as documented [here](https://github.com/iMerica/dj-rest-auth/pull/110) and [here](https://github.com/pennersr/django-allauth/issues/1975#issuecomment-384075169). The code behind `user.delete()` tries to delete associated records from `socialaccount` tables that are only created when the app is added to `INSTALLED_APPS` and migrations are applied. Make sure to run migrations after switching to this branch!