### PR TITLE
Fix/historical person component

### DIFF
--- a/frontend/src/app/data-entry/agent-form/agent-historical-person-form/agent-historical-person-form.component.html
+++ b/frontend/src/app/data-entry/agent-form/agent-historical-person-form/agent-historical-person-form.component.html
@@ -1,20 +1,20 @@
-<fieldset *ngIf="isGroup$ | async as isGroup">
-    <ng-container >
-        <legend>
-            {{ isGroup ? "Historical persons" : "Historical person" }}
-        </legend>
-        <p class="form-text">
-            {{
-                isGroup
-                    ? "Pick one or more historical persons that are represented by this agent in this source."
-                    : "Pick an historical person that is represented by this agent in this source."
-            }}
-        </p>
+<fieldset *ngIf="isGroup !== undefined">
+    <legend>
+        {{ isGroup ? "Historical persons" : "Historical person" }}
+    </legend>
+    <p class="form-text">
+        {{
+            isGroup
+                ? "Pick one or more historical persons that are represented by this agent in this source."
+                : "Pick an historical person that is represented by this agent in this source."
+        }}
+    </p>
+    <ng-container>
+        <lc-historical-person-select
+            *ngIf="historicalPersonOptions$ | async as options"
+            [formControl]="form.controls.describes"
+            [options]="options"
+            [multiple]="isGroup"
+        />
     </ng-container>
-    <lc-historical-person-select
-    *ngIf="historicalPersonOptions$ | async as options"
-        [formControl]="form.controls.describes"
-        [options]="options"
-        [multiple]="isGroup"
-    />
 </fieldset>

--- a/frontend/src/app/data-entry/agent-form/agent-historical-person-form/agent-historical-person-form.component.ts
+++ b/frontend/src/app/data-entry/agent-form/agent-historical-person-form/agent-historical-person-form.component.ts
@@ -58,10 +58,7 @@ export class AgentHistoricalPersonFormComponent implements OnInit, OnDestroy {
             )
         );
 
-    public isGroup$ = this.agent$.pipe(
-        map((agent) => agent?.isGroup ?? false),
-        share()
-    );
+    public isGroup?: boolean;
 
     public form = new FormGroup<HistoricalPersonForm>({
         describes: new FormControl<string[]>([], { nonNullable: true }),
@@ -85,7 +82,11 @@ export class AgentHistoricalPersonFormComponent implements OnInit, OnDestroy {
         this.agent$
             .pipe(takeUntilDestroyed(this.destroyRef))
             .subscribe((agent) => {
-                const historicalPersonIds = agent?.describes.map(
+                if (!agent) {
+                    return;
+                }
+                this.isGroup = agent.isGroup;
+                const historicalPersonIds = agent.describes.map(
                     (person) => person.id
                 );
                 this.form.patchValue({ describes: historicalPersonIds });


### PR DESCRIPTION
Right after deployment, I noticed that the Historical Person Select component is broken (because of an `async` check in the template). Getting it to work with async pipes turned out to be a hassle, so I settled for the classic imperative approach, which keeps things readable.

Note that this PR is set to merge into `main`.

