### PR TITLE
Add "editable" property to graphql types

### DIFF
--- a/backend/event/types/EpisodeType.py
+++ b/backend/event/types/EpisodeType.py
@@ -1,4 +1,4 @@
-from graphene import List, NonNull, ResolveInfo
+from graphene import List, NonNull, ResolveInfo, Boolean
 from graphene_django import DjangoObjectType
 from core.types.EntityDescriptionType import EntityDescriptionType
 from django.db.models import QuerySet
@@ -7,6 +7,7 @@ from event.models import Episode, EpisodeCategory
 from event.types.EpisodeCategoryType import EpisodeCategoryType
 from person.models import AgentDescription
 from space.models import SpaceDescription
+from user.permissions import can_edit_source
 
 
 class EpisodeType(EntityDescriptionType, DjangoObjectType):
@@ -15,6 +16,7 @@ class EpisodeType(EntityDescriptionType, DjangoObjectType):
         NonNull("person.types.AgentDescriptionType.AgentDescriptionType"), required=True
     )
     spaces = List(NonNull("space.types.SpaceDescriptionType.SpaceDescriptionType"), required=True)
+    editable = Boolean(required=True)
 
     class Meta:
         model = Episode
@@ -56,3 +58,7 @@ class EpisodeType(EntityDescriptionType, DjangoObjectType):
         parent: Episode, info: ResolveInfo
     ) -> QuerySet[EpisodeCategory]:
         return parent.categories.all()
+
+    @staticmethod
+    def resolve_editable(parent: Episode, info: ResolveInfo) -> bool:
+        return can_edit_source(info.context.user, parent.source)

--- a/backend/letter/types/GiftDescriptionType.py
+++ b/backend/letter/types/GiftDescriptionType.py
@@ -1,4 +1,4 @@
-from graphene import List, NonNull, ResolveInfo
+from graphene import List, NonNull, ResolveInfo, Boolean
 from graphene_django import DjangoObjectType
 from django.db.models import QuerySet
 
@@ -8,6 +8,7 @@ from letter.types.GiftDescriptionCategoryType import GiftDescriptionCategoryType
 from letter.types.GiftCategoryType import GiftCategoryType
 from event.types.EpisodeGiftType import EpisodeGiftType
 from event.models import EpisodeGift
+from user.permissions import can_edit_source
 
 class GiftDescriptionType(EntityDescriptionType, DjangoObjectType):
     # Direct access to foreign key
@@ -15,6 +16,8 @@ class GiftDescriptionType(EntityDescriptionType, DjangoObjectType):
     # Through model
     categorisations = List(NonNull(GiftDescriptionCategoryType), required=True)
     episodes = List(NonNull(EpisodeGiftType), required=True)
+    # Computed
+    editable = Boolean(required=True)
 
     class Meta:
         model = GiftDescription
@@ -48,3 +51,7 @@ class GiftDescriptionType(EntityDescriptionType, DjangoObjectType):
         parent: GiftDescription, info: ResolveInfo
     ) -> QuerySet[EpisodeGift]:
         return EpisodeGift.objects.filter(gift=parent)
+
+    @staticmethod
+    def resolve_editable(parent: GiftDescription, info: ResolveInfo) -> bool:
+        return can_edit_source(info.context.user, parent.source)

--- a/backend/letter/types/LetterDescriptionType.py
+++ b/backend/letter/types/LetterDescriptionType.py
@@ -1,4 +1,4 @@
-from graphene import List, NonNull, ResolveInfo
+from graphene import List, NonNull, ResolveInfo, Boolean
 from graphene_django import DjangoObjectType
 from django.db.models import QuerySet
 
@@ -8,6 +8,7 @@ from letter.types.LetterCategoryType import LetterCategoryType
 from letter.types.LetterDescriptionCategoryType import LetterDescriptionCategoryType
 from event.models import EpisodeLetter
 from event.types.EpisodeLetterType import EpisodeLetterType
+from user.permissions import can_edit_source
 
 class LetterDescriptionType(EntityDescriptionType, DjangoObjectType):
     # Direct access to foreign key
@@ -15,6 +16,8 @@ class LetterDescriptionType(EntityDescriptionType, DjangoObjectType):
     # Through model
     categorisations = List(NonNull(LetterDescriptionCategoryType), required=True)
     episodes = List(NonNull(EpisodeLetterType), required=True)
+    # Computed
+    editable = Boolean(required=True)
 
     class Meta:
         model = LetterDescription
@@ -48,3 +51,7 @@ class LetterDescriptionType(EntityDescriptionType, DjangoObjectType):
         parent: LetterDescription, info: ResolveInfo
     ) -> QuerySet[EpisodeLetter]:
         return EpisodeLetter.objects.filter(letter=parent)
+
+    @staticmethod
+    def resolve_editable(parent: LetterDescription, info: ResolveInfo) -> bool:
+        return can_edit_source(info.context.user, parent.source)

--- a/backend/person/types/AgentDescriptionType.py
+++ b/backend/person/types/AgentDescriptionType.py
@@ -10,6 +10,7 @@ from person.types.HistoricalPersonType import HistoricalPersonType
 from person.types.PersonReferenceType import PersonReferenceType
 from event.types.EpisodeAgentType import EpisodeAgentType
 from event.models import EpisodeAgent
+from user.permissions import can_edit_source
 
 
 class AgentDescriptionType(EntityDescriptionType, DjangoObjectType):
@@ -19,6 +20,7 @@ class AgentDescriptionType(EntityDescriptionType, DjangoObjectType):
     location = Field(AgentDescriptionLocationType)
     episodes = List(NonNull(EpisodeAgentType), required=True)
     identified = Boolean(required=True)
+    editable = Boolean(required=True)
 
     class Meta:
         model = AgentDescription
@@ -60,3 +62,7 @@ class AgentDescriptionType(EntityDescriptionType, DjangoObjectType):
     @staticmethod
     def resolve_identified(parent: AgentDescription, info: ResolveInfo) -> bool:
         return parent.identified()
+
+    @staticmethod
+    def resolve_editable(parent: AgentDescription, info: ResolveInfo) -> bool:
+        return can_edit_source(info.context.user, parent.source)

--- a/backend/source/types/SourceType.py
+++ b/backend/source/types/SourceType.py
@@ -1,4 +1,4 @@
-from graphene import Field, Int, List, NonNull, ResolveInfo
+from graphene import Field, Int, List, NonNull, ResolveInfo, Boolean
 from django.db.models import QuerySet
 from graphene_django import DjangoObjectType
 from typing import Type
@@ -16,6 +16,7 @@ from letter.models import GiftDescription, LetterDescription
 from core.models import EntityDescription
 from space.models import SpaceDescription
 from space.types.SpaceDescriptionType import SpaceDescriptionType
+from user.permissions import can_edit_source
 
 
 class SourceType(DjangoObjectType):
@@ -27,6 +28,7 @@ class SourceType(DjangoObjectType):
     gifts = List(NonNull(GiftDescriptionType), required=True)
     letters = List(NonNull(LetterDescriptionType), required=True)
     spaces = List(NonNull(SpaceDescriptionType), required=True)
+    editable = Boolean(required=True)
 
     class Meta:
         model = Source
@@ -64,3 +66,7 @@ class SourceType(DjangoObjectType):
     @staticmethod
     def resolve_num_of_episodes(parent: Source, info: ResolveInfo) -> int:
         return SourceType.resolve_episodes(parent, info).count()
+
+    @staticmethod
+    def resolve_editable(parent: Source, info: ResolveInfo) -> bool:
+        return can_edit_source(info.context.user, parent)

--- a/backend/space/types/SpaceDescriptionType.py
+++ b/backend/space/types/SpaceDescriptionType.py
@@ -20,6 +20,7 @@ from space.types.SettlementFieldType import SettlementFieldType
 from space.types.StructureFieldType import StructureFieldType
 from event.types.EpisodeSpaceType import EpisodeSpaceType
 from event.models import EpisodeSpace
+from user.permissions import can_edit_source
 
 class SpaceDescriptionType(EntityDescriptionType, DjangoObjectType):
     regions = List(NonNull(RegionType), required=True)
@@ -32,6 +33,8 @@ class SpaceDescriptionType(EntityDescriptionType, DjangoObjectType):
     structure_fields = List(NonNull(StructureFieldType), required=True)
 
     episodes = List(NonNull(EpisodeSpaceType), required=True)
+
+    editable = Boolean(required=True)
 
     class Meta:
         model = SpaceDescription
@@ -103,3 +106,7 @@ class SpaceDescriptionType(EntityDescriptionType, DjangoObjectType):
         parent: SpaceDescription, info: ResolveInfo
     ) -> Boolean:
         return parent.has_identifiable_features()
+
+    @staticmethod
+    def resolve_editable(parent: SpaceDescription, info: ResolveInfo) -> bool:
+        return can_edit_source(info.context.user, parent.source)

--- a/frontend/generated/graphql.ts
+++ b/frontend/generated/graphql.ts
@@ -815,6 +815,7 @@ export type SourceType = {
   __typename?: 'SourceType';
   agents: Array<AgentDescriptionType>;
   contentsDate?: Maybe<SourceContentsDateType>;
+  contributors: Array<UserType>;
   /** The name of the author of the edition */
   editionAuthor: Scalars['String']['output'];
   /** The title of the edition used for this source */


### PR DESCRIPTION
Adds a property `editable` to several graphql types to check whether the user is allowed to edit the object.