### PR TITLE
richer data views

### DIFF
--- a/backend/event/types/EpisodeType.py
+++ b/backend/event/types/EpisodeType.py
@@ -3,19 +3,21 @@ from graphene_django import DjangoObjectType
 from core.types.EntityDescriptionType import EntityDescriptionType
 from django.db.models import QuerySet
 
-from event.models import Episode, EpisodeCategory
+from event.models import (
+    Episode, EpisodeCategory, EpisodeAgent, EpisodeSpace, EpisodeLetter, EpisodeGift,
+)
 from event.types.EpisodeCategoryType import EpisodeCategoryType
-from person.models import AgentDescription
-from space.models import SpaceDescription
 from user.permissions import can_edit_source
 
 
 class EpisodeType(EntityDescriptionType, DjangoObjectType):
     categories = List(NonNull(EpisodeCategoryType), required=True)
     agents = List(
-        NonNull("person.types.AgentDescriptionType.AgentDescriptionType"), required=True
+        NonNull("event.types.EpisodeAgentType.EpisodeAgentType"), required=True
     )
-    spaces = List(NonNull("space.types.SpaceDescriptionType.SpaceDescriptionType"), required=True)
+    spaces = List(NonNull("event.types.EpisodeSpaceType.EpisodeSpaceType"), required=True)
+    letters = List(NonNull("event.types.EpisodeLetterType.EpisodeLetterType"), required=True)
+    gifts = List(NonNull("event.types.EpisodeGiftType.EpisodeGiftType"), required=True)
     editable = Boolean(required=True)
 
     class Meta:
@@ -42,16 +44,27 @@ class EpisodeType(EntityDescriptionType, DjangoObjectType):
     @staticmethod
     def resolve_agents(
         parent: Episode, info: ResolveInfo
-    ) -> QuerySet[AgentDescription]:
-        # Without distinct(), this returns one agent for every HistoricalPerson linked
-        # to that agent, for some reason.
-        return parent.agents.distinct()
+    ) -> QuerySet[EpisodeAgent]:
+        return EpisodeAgent.objects.filter(episode=parent)
 
     @staticmethod
     def resolve_spaces(
         parent: Episode, info: ResolveInfo
-    ) -> QuerySet[SpaceDescription]:
-        return parent.spaces.distinct()
+    ) -> QuerySet[EpisodeSpace]:
+        return EpisodeSpace.objects.filter(episode=parent)
+
+    @staticmethod
+    def resolve_gifts(
+        parent: Episode, info: ResolveInfo
+    ) -> QuerySet[EpisodeGift]:
+        return EpisodeGift.objects.filter(episode=parent)
+
+    @staticmethod
+    def resolve_letters(
+        parent: Episode, info: ResolveInfo
+    ) -> QuerySet[EpisodeLetter]:
+        return EpisodeLetter.objects.filter(episode=parent)
+
 
     @staticmethod
     def resolve_categories(

--- a/frontend/src/app/data-entry/episode-form/episode-entities-form/episode-entities-form.component.ts
+++ b/frontend/src/app/data-entry/episode-form/episode-entities-form/episode-entities-form.component.ts
@@ -89,7 +89,7 @@ export class EpisodeEntitiesFormComponent implements OnChanges, OnDestroy {
     }
 
     /** property used for the entity relationship in graphQL data */
-    get entityProperty(): EntityPropertyName {
+    get entityListPath(): EntityPropertyName {
         const keys: Record<Entity, EntityPropertyName> = {
             [Entity.Agent]: 'agents',
             [Entity.Gift]: 'gifts',
@@ -165,7 +165,7 @@ export class EpisodeEntitiesFormComponent implements OnChanges, OnDestroy {
     }
 
     private linkedEntities(data: DataEntryEpisodeEntitiesQuery): { id: string, name: string }[] {
-        return data.episode?.[this.entityProperty] || [];
+        return data.episode?.[this.entityListPath].map(link => link.entity) || [];
     }
 
     private availableEntities(
@@ -175,7 +175,7 @@ export class EpisodeEntitiesFormComponent implements OnChanges, OnDestroy {
             __typename?: string,
             name: string,
             id: string
-        }[] = data.episode?.source[this.entityProperty] || [];
+        }[] = data.episode?.source[this.entityListPath] || [];
         const linkedEntities = this.linkedEntities(data);
         return differenceBy(allEntities, linkedEntities, 'id');
     }
@@ -186,7 +186,7 @@ export class EpisodeEntitiesFormComponent implements OnChanges, OnDestroy {
                 __typename: "EpisodeType",
                 id: episodeID,
             }),
-            fieldName: this.entityProperty,
+            fieldName: this.entityListPath,
         });
         cache.evict({
             id: cache.identify({

--- a/frontend/src/app/data-entry/episode-form/episode-entities-form/episode-entities.graphql
+++ b/frontend/src/app/data-entry/episode-form/episode-entities-form/episode-entities.graphql
@@ -21,24 +21,28 @@ query DataEntryEpisodeEntities($id: ID!) {
       }
     }
     agents {
+        id
         entity {
             id
             name
         }
     }
     gifts {
+        id
         entity {
             id
             name
         }
     }
     letters {
+        id
         entity {
             id
             name
         }
     }
     spaces {
+        id
         entity {
             id
             name

--- a/frontend/src/app/data-entry/episode-form/episode-entities-form/episode-entities.graphql
+++ b/frontend/src/app/data-entry/episode-form/episode-entities-form/episode-entities.graphql
@@ -21,20 +21,28 @@ query DataEntryEpisodeEntities($id: ID!) {
       }
     }
     agents {
-      id
-      name
+        entity {
+            id
+            name
+        }
     }
     gifts {
-      id
-      name
+        entity {
+            id
+            name
+        }
     }
     letters {
-      id
-      name
+        entity {
+            id
+            name
+        }
     }
     spaces {
-      id
-      name
+        entity {
+            id
+            name
+        }
     }
   }
 }

--- a/frontend/src/app/data-entry/source/episode-preview/episode-preview.component.html
+++ b/frontend/src/app/data-entry/source/episode-preview/episode-preview.component.html
@@ -33,6 +33,14 @@
             <ng-template #noSummary><i>(No summary added.)</i></ng-template>
         </p>
 
+        <ul class="inline-list no-delimiter">
+            <li *ngFor="let category of episode.categories"
+                class="inline-list-item">
+                <span class="badge rounded-pill text-bg-secondary">
+                    {{category.name}}
+                </span>
+            </li>
+        </ul>
         <dl>
             <dt>Agents</dt>
             <dd *ngIf="episode.agents.length > 0; else noAgents" class="ms-4">

--- a/frontend/src/app/data-entry/source/episode-preview/episode-preview.component.html
+++ b/frontend/src/app/data-entry/source/episode-preview/episode-preview.component.html
@@ -46,15 +46,15 @@
             <dd *ngIf="episode.agents.length > 0; else noAgents" class="ms-4">
                 <ul class="inline-list">
                     <li
-                        *ngFor="let agent of episode.agents"
+                        *ngFor="let link of episode.agents"
                         class="inline-list-item"
                     >
                         <a
-                            [routerLink]="['/', 'data-entry', 'agents', agent.id]"
+                            [routerLink]="['/', 'data-entry', 'agents', link.agent.id]"
                             class="icon-link"
                         >
-                            <lc-icon [icon]="agentIcon(agent)" />
-                            {{ agent.name }}
+                            <lc-icon [icon]="agentIcon(link.agent)" />
+                            {{ link.agent.name }}
                         </a>
                     </li>
                 </ul>
@@ -67,15 +67,15 @@
             <dd *ngIf="episode.spaces.length > 0; else noSpaces" class="ms-4">
                 <ul class="inline-list">
                     <li
-                        *ngFor="let space of episode.spaces"
+                        *ngFor="let link of episode.spaces"
                         class="inline-list-item"
                     >
                         <a
-                            [routerLink]="['/', 'data-entry', 'locations', space.id]"
+                            [routerLink]="['/', 'data-entry', 'locations', link.space.id]"
                             class="icon-link"
                         >
-                            <lc-icon [icon]="locationIcon(space)" />
-                            {{ space.name }}
+                            <lc-icon [icon]="locationIcon(link.space)" />
+                            {{ link.space.name }}
                         </a>
                     </li>
                 </ul>
@@ -94,27 +94,27 @@
             >
                 <ul class="inline-list">
                     <li
-                        *ngFor="let gift of episode.gifts"
+                        *ngFor="let link of episode.gifts"
                         class="inline-list-item"
                     >
                         <a
-                            [routerLink]="['/', 'data-entry', 'gifts', gift.id]"
+                            [routerLink]="['/', 'data-entry', 'gifts', link.gift.id]"
                             class="icon-link"
                         >
                             <lc-icon [icon]="dataIcons.gift" />
-                            {{ gift.name }}
+                            {{ link.gift.name }}
                         </a>
                     </li>
                     <li
-                        *ngFor="let letter of episode.letters"
+                        *ngFor="let link of episode.letters"
                         class="inline-list-item"
                     >
                         <a
-                            [routerLink]="['/data-entry', 'letters', letter.id]"
+                            [routerLink]="['/data-entry', 'letters', link.letter.id]"
                             class="icon-link"
                         >
                             <lc-icon [icon]="dataIcons.letter" />
-                            {{ letter.name }}
+                            {{ link.letter.name }}
                         </a>
                     </li>
                 </ul>

--- a/frontend/src/app/data-entry/source/episode-preview/episode-preview.component.spec.ts
+++ b/frontend/src/app/data-entry/source/episode-preview/episode-preview.component.spec.ts
@@ -17,7 +17,6 @@ describe("EpisodePreviewComponent", () => {
         component.episode = {
             id: '1',
             name: 'Test',
-            description: 'Test episode',
             summary: '',
             book: '',
             chapter: '',
@@ -27,6 +26,7 @@ describe("EpisodePreviewComponent", () => {
             gifts: [],
             letters: [],
             spaces: [],
+            categories: [],
         }
         fixture.detectChanges();
     });

--- a/frontend/src/app/data-entry/source/source.graphql
+++ b/frontend/src/app/data-entry/source/source.graphql
@@ -5,8 +5,11 @@ query DataEntrySourceDetail($id: ID!) {
         episodes {
             id
             name
-            description
             summary
+            categories {
+                id
+                name
+            }
             book
             chapter
             contributors {

--- a/frontend/src/app/data-entry/source/source.graphql
+++ b/frontend/src/app/data-entry/source/source.graphql
@@ -18,23 +18,31 @@ query DataEntrySourceDetail($id: ID!) {
             }
             page
             agents {
-                id
-                name
-                isGroup
-                identified
+                agent {
+                    id
+                    name
+                    isGroup
+                    identified
+                }
             }
             gifts {
-                id
-                name
+                gift {
+                    id
+                    name
+                }
             }
             letters {
-                id
-                name
+                letter {
+                    id
+                    name
+                }
             }
             spaces {
-                id
-                name
-                hasIdentifiableFeatures
+                space {
+                    id
+                    name
+                    hasIdentifiableFeatures
+                }
             }
         }
     }

--- a/frontend/src/app/data/agent-view/agent-view.component.html
+++ b/frontend/src/app/data/agent-view/agent-view.component.html
@@ -13,10 +13,15 @@
 
         <lc-contributors [contributors]="agent.contributors" />
 
-        <section class="mb-5">
+        <section class="mt-5">
             <h2>Description</h2>
 
             <dl>
+                <dt>Indivdual or group</dt>
+                <dd class="ms-4">
+                    {{ agent.isGroup ? 'Group' : 'Individual' }}
+                </dd>
+
                 <dt *ngIf="agent.gender">Gender</dt>
                 <dd *ngIf="agent.gender as gender" class="ms-4">
                     <p>
@@ -30,7 +35,7 @@
             </dl>
         </section>
 
-        <section class="mb-5">
+        <section class="mt-5">
             <h2>Source text</h2>
 
             <p>
@@ -52,8 +57,13 @@
             <lc-episode-links [episodes]="agent.episodes" />
         </section>
 
-        <section *ngIf="agent.personReferences.length">
+        <section class="mt-5">
             <h2>Historical context</h2>
+
+            <p *ngIf="!agent.personReferences.length">
+                <i>This agent is not linked to any historic figures in the database.
+                </i>
+            </p>
 
             <ng-container *ngIf="agent.isGroup; else singularReference">
                 <p>

--- a/frontend/src/app/data/agent-view/agent-view.component.html
+++ b/frontend/src/app/data/agent-view/agent-view.component.html
@@ -60,39 +60,42 @@
         <section class="mt-5">
             <h2>Historical context</h2>
 
-            <p *ngIf="!agent.personReferences.length">
-                <i>This agent is not linked to any historic figures in the database.
-                </i>
-            </p>
-
-            <ng-container *ngIf="agent.isGroup; else singularReference">
-                <p>
-                    This group includes the following historical figures:
-                </p>
-                <ul>
-                    <li *ngFor="let ref of agent.personReferences">
-                        <a [routerLink]="['/data/historical-figures', ref.person.id]">{{ref.person.name}}</a>
-                        <ng-container *ngIf="ref.certainty === Certainty.SomewhatCertain">(somewhat certain)</ng-container>
-                        <ng-container *ngIf="ref.certainty === Certainty.Uncertain">(uncertain)</ng-container>
-                        <ng-container *ngIf="ref.note">; <i>Note: {{ref.note}}</i></ng-container>
-                    </li>
-                </ul>
-            </ng-container>
-            <ng-template #singularReference>
-                <ng-container *ngIf="agent.personReferences[0] as ref">
+            <ng-container *ngIf="agent.personReferences.length; else noReferences">
+                <ng-container *ngIf="agent.isGroup; else singularReference">
                     <p>
-                        This agent is a representation of
-                        <a [routerLink]="['/data/historical-figures', ref.person.id]">
-                            {{ref.person.name}}</a>
-                        <ng-container *ngIf="ref.certainty === Certainty.SomewhatCertain">
-                            (somewhat certain)
-                        </ng-container>
-                        <ng-container *ngIf="ref.certainty === Certainty.Uncertain">
-                            (uncertain)
-                        </ng-container>.
-                        <i *ngIf="ref.note">Note: {{ref.note}}</i>
+                        This group includes the following historical figures:
                     </p>
+                    <ul>
+                        <li *ngFor="let ref of agent.personReferences">
+                            <a [routerLink]="['/data/historical-figures', ref.person.id]">{{ref.person.name}}</a>
+                            <ng-container *ngIf="ref.certainty === Certainty.SomewhatCertain">(somewhat certain)</ng-container>
+                            <ng-container *ngIf="ref.certainty === Certainty.Uncertain">(uncertain)</ng-container>
+                            <ng-container *ngIf="ref.note">; <i>Note: {{ref.note}}</i></ng-container>
+                        </li>
+                    </ul>
                 </ng-container>
+                <ng-template #singularReference>
+                    <ng-container *ngIf="agent.personReferences[0] as ref">
+                        <p>
+                            This agent is a representation of
+                            <a [routerLink]="['/data/historical-figures', ref.person.id]">
+                                {{ref.person.name}}</a>
+                            <ng-container *ngIf="ref.certainty === Certainty.SomewhatCertain">
+                                (somewhat certain)
+                            </ng-container>
+                            <ng-container *ngIf="ref.certainty === Certainty.Uncertain">
+                                (uncertain)
+                            </ng-container>.
+                            <i *ngIf="ref.note">Note: {{ref.note}}</i>
+                        </p>
+                    </ng-container>
+                </ng-template>
+            </ng-container>
+
+            <ng-template #noReferences>
+                <p><i>
+                    This agent is not linked to any historic figures in the database.
+                </i></p>
             </ng-template>
         </section>
     </ng-container>

--- a/frontend/src/app/data/agent-view/agent-view.component.html
+++ b/frontend/src/app/data/agent-view/agent-view.component.html
@@ -17,7 +17,7 @@
             <h2>Description</h2>
 
             <dl>
-                <dt>Indivdual or group</dt>
+                <dt>Individual or group</dt>
                 <dd class="ms-4">
                     {{ agent.isGroup ? 'Group' : 'Individual' }}
                 </dd>

--- a/frontend/src/app/data/agent-view/agent-view.component.html
+++ b/frontend/src/app/data/agent-view/agent-view.component.html
@@ -54,7 +54,7 @@
                 </ng-container>
             </p>
 
-            <lc-episode-links [episodes]="agent.episodes" />
+            <lc-episode-links [data]="agent.episodes" />
         </section>
 
         <section class="mt-5">

--- a/frontend/src/app/data/episode-list/episode-list.graphql
+++ b/frontend/src/app/data/episode-list/episode-list.graphql
@@ -2,8 +2,11 @@ query ViewEpisodes {
   episodes {
     id
     name
-    description
     summary
+    categories {
+        id
+        name
+    }
     book
     chapter
     contributors {

--- a/frontend/src/app/data/episode-view/episode-view.component.html
+++ b/frontend/src/app/data/episode-view/episode-view.component.html
@@ -72,51 +72,19 @@
 
         <h2 class="mt-5">Agents</h2>
 
-        <p>
-            This episode involves the following agents:
-        </p>
-
-        <ul class="list-group">
-            <li class="list-group-item" *ngFor="let link of episode.agents">
-                <a [routerLink]="['/data/agents', link.agent.id]" class="icon-link">
-                    <lc-icon [icon]="agentIcon(link.agent)" />
-                    {{link.agent.name}}
-                </a>
-            </li>
-        </ul>
+        <p>This episode involves the following agents:</p>
+        <lc-episode-links [data]="episode.agents" />
 
         <h2 class="mt-5">Objects</h2>
 
         <p>This episode involves the following epistolary objects:</p>
 
-        <ul class="list-group">
-            <li class="list-group-item" *ngFor="let link of episode.letters">
-                <a [routerLink]="['/data/letters', link.letter.id]" class="icon-link">
-                    <lc-icon [icon]="dataIcons.letter" />
-                    {{link.letter.name}}
-                </a>
-            </li>
-            <li class="list-group-item" *ngFor="let link of episode.gifts">
-                <a [routerLink]="['/data/gifts', link.gift.id]" class="icon-link">
-                    <lc-icon [icon]="dataIcons.gift" />
-                    {{link.gift.name}}
-                </a>
-            </li>
-        </ul>
+        <lc-episode-links [data]="episodeObjects(episode)" />
 
         <h2 class="mt-5">Locations</h2>
 
-        <p>
-            This episode involves the following locations:
-        </p>
+        <p>This episode involves the following locations:</p>
+        <lc-episode-links [data]="episode.spaces" />
 
-        <ul class="list-group">
-            <li class="list-group-item" *ngFor="let link of episode.spaces">
-                <a [routerLink]="['/data/locations', link.space.id]" class="icon-link">
-                    <lc-icon [icon]="locationIcon(link.space)" />
-                    {{link.space.name}}
-                </a>
-            </li>
-        </ul>
     </ng-container>
 </ng-container>

--- a/frontend/src/app/data/episode-view/episode-view.component.html
+++ b/frontend/src/app/data/episode-view/episode-view.component.html
@@ -19,6 +19,28 @@
 
         <lc-contributors [contributors]="episode.contributors" />
 
+        <h2 class="mt-5">Source text</h2>
+
+        <dl>
+            <dt>Source text</dt>
+            <dd class="ms-4">
+                <a [routerLink]="['/data/sources', episode.source.id]" class="icon-link">
+                    <lc-icon [icon]="dataIcons.source" />
+                    {{episode.source.name}}</a>
+            </dd>
+            <dt>Location in text</dt>
+            <dd class="ms-4">
+                <span class="inline-list">
+                    <span *ngIf="episode.book" class="inline-list-item">book {{ episode.book }}</span>
+                    <span *ngIf="episode.chapter" class="inline-list-item">chapter {{ episode.chapter }}</span>
+                    <span *ngIf="episode.page" class="inline-list-item">page {{ episode.page }}</span>
+                </span>
+                <i *ngIf="!(episode.book || episode.chapter || episode.page)">
+                    Location not specified.
+                </i>
+            </dd>
+        </dl>
+
         <h2 class="mt-5">Content</h2>
 
         <dl>
@@ -37,9 +59,10 @@
 
             <dt>Labels</dt>
             <dd class="ms-4">
-                <ul class="inline-list mt-1">
-                    <li *ngFor="let category of episode.categories" class="inline-list-item">
-                        <span class="badge rounded-pill text-bg-primary fs-6 fw-normal">
+                <ul class="inline-list no-delimiter">
+                    <li *ngFor="let category of episode.categories"
+                        class="inline-list-item">
+                        <span class="badge rounded-pill text-bg-secondary">
                             {{category.name}}
                         </span>
                     </li>

--- a/frontend/src/app/data/episode-view/episode-view.component.html
+++ b/frontend/src/app/data/episode-view/episode-view.component.html
@@ -77,10 +77,10 @@
         </p>
 
         <ul class="list-group">
-            <li class="list-group-item" *ngFor="let agent of episode.agents">
-                <a [routerLink]="['/data/agents', agent.id]" class="icon-link">
-                    <lc-icon [icon]="agentIcon(agent)" />
-                    {{agent.name}}
+            <li class="list-group-item" *ngFor="let link of episode.agents">
+                <a [routerLink]="['/data/agents', link.agent.id]" class="icon-link">
+                    <lc-icon [icon]="agentIcon(link.agent)" />
+                    {{link.agent.name}}
                 </a>
             </li>
         </ul>
@@ -90,16 +90,16 @@
         <p>This episode involves the following epistolary objects:</p>
 
         <ul class="list-group">
-            <li class="list-group-item" *ngFor="let letter of episode.letters">
-                <a [routerLink]="['/data/letters', letter.id]" class="icon-link">
+            <li class="list-group-item" *ngFor="let link of episode.letters">
+                <a [routerLink]="['/data/letters', link.letter.id]" class="icon-link">
                     <lc-icon [icon]="dataIcons.letter" />
-                    {{letter.name}}
+                    {{link.letter.name}}
                 </a>
             </li>
-            <li class="list-group-item" *ngFor="let gift of episode.gifts">
-                <a [routerLink]="['/data/gifts', gift.id]" class="icon-link">
+            <li class="list-group-item" *ngFor="let link of episode.gifts">
+                <a [routerLink]="['/data/gifts', link.gift.id]" class="icon-link">
                     <lc-icon [icon]="dataIcons.gift" />
-                    {{gift.name}}
+                    {{link.gift.name}}
                 </a>
             </li>
         </ul>
@@ -111,10 +111,10 @@
         </p>
 
         <ul class="list-group">
-            <li class="list-group-item" *ngFor="let location of episode.spaces">
-                <a [routerLink]="['/data/locations', location.id]" class="icon-link">
-                    <lc-icon [icon]="locationIcon(location)" />
-                    {{location.name}}
+            <li class="list-group-item" *ngFor="let link of episode.spaces">
+                <a [routerLink]="['/data/locations', link.space.id]" class="icon-link">
+                    <lc-icon [icon]="locationIcon(link.space)" />
+                    {{link.space.name}}
                 </a>
             </li>
         </ul>

--- a/frontend/src/app/data/episode-view/episode-view.component.ts
+++ b/frontend/src/app/data/episode-view/episode-view.component.ts
@@ -45,4 +45,13 @@ export class EpisodeViewComponent {
             ];
         }
     }
+
+    episodeObjects(episode: ViewEpisodeQuery['episode']): any[] {
+        if (episode) {
+            return [...episode.letters, ...episode.gifts];
+        } else {
+            return [];
+        }
+
+    }
 }

--- a/frontend/src/app/data/episode-view/episode-view.graphql
+++ b/frontend/src/app/data/episode-view/episode-view.graphql
@@ -21,23 +21,31 @@ query ViewEpisode($id: ID!) {
         name
     }
     agents {
-        id
-        name
-        isGroup
-        identified
+        agent {
+            id
+            name
+            isGroup
+            identified
+        }
     }
     spaces {
-        id
-        name
-        hasIdentifiableFeatures
+        space {
+            id
+            name
+            hasIdentifiableFeatures
+        }
     }
     letters {
-        id
-        name
+        letter {
+            id
+            name
+        }
     }
     gifts {
-        id
-        name
+        gift {
+            id
+            name
+        }
     }
   }
 }

--- a/frontend/src/app/data/episode-view/episode-view.graphql
+++ b/frontend/src/app/data/episode-view/episode-view.graphql
@@ -21,6 +21,10 @@ query ViewEpisode($id: ID!) {
         name
     }
     agents {
+        id
+        sourceMention
+        note
+        designators
         agent {
             id
             name
@@ -29,6 +33,10 @@ query ViewEpisode($id: ID!) {
         }
     }
     spaces {
+        id
+        sourceMention
+        note
+        designators
         space {
             id
             name
@@ -36,12 +44,20 @@ query ViewEpisode($id: ID!) {
         }
     }
     letters {
+        id
+        sourceMention
+        note
+        designators
         letter {
             id
             name
         }
     }
     gifts {
+        id
+        sourceMention
+        note
+        designators
         gift {
             id
             name

--- a/frontend/src/app/data/episode-view/episode-view.graphql
+++ b/frontend/src/app/data/episode-view/episode-view.graphql
@@ -2,12 +2,14 @@ query ViewEpisode($id: ID!) {
   episode(id: $id) {
     id
     name
-    description
     editable
     source {
         id
         name
     }
+    book
+    chapter
+    page
     contributors {
         id
         fullName

--- a/frontend/src/app/data/gift-view/gift-view.component.html
+++ b/frontend/src/app/data/gift-view/gift-view.component.html
@@ -26,7 +26,7 @@
                 </ng-container>
             </p>
 
-            <lc-episode-links [episodes]="gift.episodes" />
+            <lc-episode-links [data]="gift.episodes" />
         </section>
     </ng-container>
 </ng-container>

--- a/frontend/src/app/data/letter-view/letter-view.component.html
+++ b/frontend/src/app/data/letter-view/letter-view.component.html
@@ -26,7 +26,7 @@
                 </ng-container>
             </p>
 
-            <lc-episode-links [episodes]="letter.episodes" />
+            <lc-episode-links [data]="letter.episodes" />
         </section>
     </ng-container>
 </ng-container>

--- a/frontend/src/app/data/location-view/location-view.component.html
+++ b/frontend/src/app/data/location-view/location-view.component.html
@@ -23,7 +23,7 @@
                 </a>. It features in the following episodes:
             </p>
 
-            <lc-episode-links [episodes]="location.episodes" />
+            <lc-episode-links [data]="location.episodes" />
         </section>
 
         <section class="mb-5">

--- a/frontend/src/app/data/shared/episode-links/episode-links.component.html
+++ b/frontend/src/app/data/shared/episode-links/episode-links.component.html
@@ -1,9 +1,10 @@
-<ul *ngIf="episodes.length" class="list-group">
-    <li *ngFor="let link of episodes" class="list-group-item">
+<ul *ngIf="data.length" class="list-group">
+    <li *ngFor="let link of data" class="list-group-item">
         <p>
-            <a [routerLink]="['/data/episodes', link.episode.id]" class="icon-link">
-                <lc-icon [icon]="dataIcons.episode"/>
-                {{link.episode.name}}
+            <a *ngIf="linkedObject(link) as obj" [routerLink]="[obj.urlSegment, obj.id]"
+                class="icon-link">
+                <lc-icon [icon]="obj.icon"/>
+                {{obj.name}}
             </a>
         </p>
         <dl>

--- a/frontend/src/app/data/shared/episode-links/episode-links.component.html
+++ b/frontend/src/app/data/shared/episode-links/episode-links.component.html
@@ -1,7 +1,7 @@
 <ul *ngIf="data.length" class="list-group">
     <li *ngFor="let link of data" class="list-group-item">
         <p>
-            <a *ngIf="linkedObject(link) as obj" [routerLink]="[obj.urlSegment, obj.id]"
+            <a *ngIf="linkedObject(link) as obj" [routerLink]="['/data', obj.urlSegment, obj.id]"
                 class="icon-link">
                 <lc-icon [icon]="obj.icon"/>
                 {{obj.name}}

--- a/frontend/src/app/data/shared/episode-links/episode-links.component.html
+++ b/frontend/src/app/data/shared/episode-links/episode-links.component.html
@@ -1,8 +1,37 @@
 <ul *ngIf="episodes.length" class="list-group">
     <li *ngFor="let link of episodes" class="list-group-item">
-        <a [routerLink]="['/data/episodes', link.episode.id]" class="icon-link">
-            <lc-icon [icon]="dataIcons.episode"/>
-            {{link.episode.name}}
-        </a>
+        <p>
+            <a [routerLink]="['/data/episodes', link.episode.id]" class="icon-link">
+                <lc-icon [icon]="dataIcons.episode"/>
+                {{link.episode.name}}
+            </a>
+        </p>
+        <dl>
+            <dt>
+                Involvement
+            </dt>
+            <dd class="ms-4">
+                {{sourceMentionLabels[link.sourceMention] | sentenceCase}}
+            </dd>
+            <ng-container *ngIf="link.designators?.length">
+                <dt>
+                    Designators
+                </dt>
+                <dd class="ms-4">
+                    <ul class="inline-list">
+                        <li *ngFor="let designator of link.designators"
+                            class="inline-list-item">"{{designator}}"</li>
+                    </ul>
+                </dd>
+            </ng-container>
+            <ng-container *ngIf="link.note">
+                <dt>
+                    Note
+                </dt>
+                <dd class="ms-4">
+                    {{link.note}}
+                </dd>
+            </ng-container>
+        </dl>
     </li>
 </ul>

--- a/frontend/src/app/data/shared/episode-links/episode-links.component.scss
+++ b/frontend/src/app/data/shared/episode-links/episode-links.component.scss
@@ -1,0 +1,4 @@
+p {
+    margin-top: 0.5rem;
+    margin-bottom: 0.5rem;
+}

--- a/frontend/src/app/data/shared/episode-links/episode-links.component.spec.ts
+++ b/frontend/src/app/data/shared/episode-links/episode-links.component.spec.ts
@@ -15,7 +15,7 @@ describe('EpisodeLinksComponent', () => {
         });
         fixture = TestBed.createComponent(EpisodeLinksComponent);
         component = fixture.componentInstance;
-        component.episodes = [
+        component.data = [
             {
                 id: '1',
                 episode: {

--- a/frontend/src/app/data/shared/episode-links/episode-links.component.ts
+++ b/frontend/src/app/data/shared/episode-links/episode-links.component.ts
@@ -31,31 +31,31 @@ export class EpisodeLinksComponent {
         if ('episode' in link) {
             return {
                 ...link.episode,
-                urlSegment: 'data/episodes',
+                urlSegment: '/data/episodes',
                 icon: dataIcons.episode,
             };
         } else if ('agent' in link) {
             return {
                 ...link.agent,
-                urlSegment: 'data/agents',
+                urlSegment: 'agents',
                 icon: agentIcon(link.agent),
             };
         } else if ('gift' in link) {
             return {
                 ...link.gift,
-                urlSegment: 'data/gifts',
+                urlSegment: 'gifts',
                 icon: dataIcons.gift,
             };
         } else if ('letter' in link) {
             return {
                 ...link.letter,
-                urlSegment: 'data/letters',
+                urlSegment: 'letters',
                 icon: dataIcons.letter,
             };
         } else {
             return {
                 ...link.space,
-                urlSegment: 'data/locations',
+                urlSegment: 'locations',
                 icon: locationIcon(link.space),
             };
         }

--- a/frontend/src/app/data/shared/episode-links/episode-links.component.ts
+++ b/frontend/src/app/data/shared/episode-links/episode-links.component.ts
@@ -1,13 +1,17 @@
 import { Component, Input } from '@angular/core';
 import { dataIcons } from '@shared/icons';
+import { agentIcon, locationIcon } from '@shared/icons-utils';
 import { sourceMentionLabels } from '@shared/labels';
-import { SourceMention, ViewAgentQuery, ViewGiftQuery, ViewLetterQuery, ViewLocationQuery } from 'generated/graphql';
+import { SourceMention, ViewAgentQuery, ViewEpisodeQuery, ViewGiftQuery, ViewLetterQuery, ViewLocationQuery } from 'generated/graphql';
 
 type QueriedEpisodeLink =
     | NonNullable<ViewAgentQuery["agentDescription"]>["episodes"][number]
     | NonNullable<ViewLetterQuery["letterDescription"]>["episodes"][number]
     | NonNullable<ViewGiftQuery["giftDescription"]>["episodes"][number]
-    | NonNullable<ViewLocationQuery["spaceDescription"]>["episodes"][number];
+    | NonNullable<ViewLocationQuery["spaceDescription"]>["episodes"][number]
+    | NonNullable<ViewEpisodeQuery['episode']>['agents'|'gifts'|'letters'|'spaces'][number];
+
+type LinkedObject = { id: string, name: string, urlSegment: string, icon: string };
 
 @Component({
   selector: 'lc-episode-links',
@@ -16,10 +20,44 @@ type QueriedEpisodeLink =
 })
 export class EpisodeLinksComponent {
     @Input({required: true})
-    episodes!: QueriedEpisodeLink[];
+    data!: QueriedEpisodeLink[];
 
     dataIcons = dataIcons;
 
     SourceMention = SourceMention;
     sourceMentionLabels = sourceMentionLabels;
+
+    linkedObject(link: QueriedEpisodeLink): LinkedObject | undefined {
+        if ('episode' in link) {
+            return {
+                ...link.episode,
+                urlSegment: 'data/episodes',
+                icon: dataIcons.episode,
+            };
+        } else if ('agent' in link) {
+            return {
+                ...link.agent,
+                urlSegment: 'data/agents',
+                icon: agentIcon(link.agent),
+            };
+        } else if ('gift' in link) {
+            return {
+                ...link.gift,
+                urlSegment: 'data/gifts',
+                icon: dataIcons.gift,
+            };
+        } else if ('letter' in link) {
+            return {
+                ...link.letter,
+                urlSegment: 'data/letters',
+                icon: dataIcons.letter,
+            };
+        } else {
+            return {
+                ...link.space,
+                urlSegment: 'data/locations',
+                icon: locationIcon(link.space),
+            };
+        }
+    }
 }

--- a/frontend/src/app/data/shared/episode-links/episode-links.component.ts
+++ b/frontend/src/app/data/shared/episode-links/episode-links.component.ts
@@ -1,6 +1,7 @@
 import { Component, Input } from '@angular/core';
 import { dataIcons } from '@shared/icons';
-import { ViewAgentQuery, ViewGiftQuery, ViewLetterQuery, ViewLocationQuery } from 'generated/graphql';
+import { sourceMentionLabels } from '@shared/labels';
+import { SourceMention, ViewAgentQuery, ViewGiftQuery, ViewLetterQuery, ViewLocationQuery } from 'generated/graphql';
 
 type QueriedEpisodeLink =
     | NonNullable<ViewAgentQuery["agentDescription"]>["episodes"][number]
@@ -18,4 +19,7 @@ export class EpisodeLinksComponent {
     episodes!: QueriedEpisodeLink[];
 
     dataIcons = dataIcons;
+
+    SourceMention = SourceMention;
+    sourceMentionLabels = sourceMentionLabels;
 }

--- a/frontend/src/app/data/source-view/episode-preview/episode-preview.component.html
+++ b/frontend/src/app/data/source-view/episode-preview/episode-preview.component.html
@@ -9,6 +9,15 @@
     <div class="card-body">
         <p *ngIf="episode.summary">{{episode.summary}}</p>
 
+        <ul class="inline-list no-delimiter">
+            <li *ngFor="let category of episode.categories"
+                class="inline-list-item">
+                <span class="badge rounded-pill text-bg-secondary">
+                    {{category.name}}
+                </span>
+            </li>
+        </ul>
+
         <dl *ngIf="hasEntities(episode)">
             <dt>Agents</dt>
             <dd *ngIf="episode.agents.length > 0; else noAgents" class="ms-4">

--- a/frontend/src/app/data/source-view/episode-preview/episode-preview.component.html
+++ b/frontend/src/app/data/source-view/episode-preview/episode-preview.component.html
@@ -30,15 +30,15 @@
             <dd *ngIf="episode.agents.length > 0; else noAgents" class="ms-4">
                 <ul class="inline-list">
                     <li
-                        *ngFor="let agent of episode.agents"
+                        *ngFor="let link of episode.agents"
                         class="inline-list-item"
                     >
                         <a
-                            [routerLink]="['/data', 'agents', agent.id]"
+                            [routerLink]="['/data', 'agents', link.agent.id]"
                             class="icon-link"
                         >
-                            <lc-icon [icon]="agentIcon(agent)" />
-                            {{ agent.name }}
+                            <lc-icon [icon]="agentIcon(link.agent)" />
+                            {{ link.agent.name }}
                         </a>
                     </li>
                 </ul>
@@ -51,15 +51,15 @@
             <dd *ngIf="episode.spaces.length > 0; else noSpaces" class="ms-4">
                 <ul class="inline-list">
                     <li
-                        *ngFor="let space of episode.spaces"
+                        *ngFor="let link of episode.spaces"
                         class="inline-list-item"
                     >
                         <a
-                            [routerLink]="['/data', 'locations', space.id]"
+                            [routerLink]="['/data', 'locations', link.space.id]"
                             class="icon-link"
                         >
-                            <lc-icon [icon]="locationIcon(space)" />
-                            {{ space.name }}
+                            <lc-icon [icon]="locationIcon(link.space)" />
+                            {{ link.space.name }}
                         </a>
                     </li>
                 </ul>
@@ -78,27 +78,27 @@
             >
                 <ul class="inline-list">
                     <li
-                        *ngFor="let gift of episode.gifts"
+                        *ngFor="let link of episode.gifts"
                         class="inline-list-item"
                     >
                         <a
-                            [routerLink]="['/data', 'gifts', gift.id]"
+                            [routerLink]="['/data', 'gifts', link.gift.id]"
                             class="icon-link"
                         >
                             <lc-icon [icon]="dataIcons.gift" />
-                            {{ gift.name }}
+                            {{ link.gift.name }}
                         </a>
                     </li>
                     <li
-                        *ngFor="let letter of episode.letters"
+                        *ngFor="let link of episode.letters"
                         class="inline-list-item"
                     >
                         <a
-                            [routerLink]="['/data', 'letters', letter.id]"
+                            [routerLink]="['/data', 'letters', link.letter.id]"
                             class="icon-link"
                         >
                             <lc-icon [icon]="dataIcons.letter" />
-                            {{ letter.name }}
+                            {{ link.letter.name }}
                         </a>
                     </li>
                 </ul>

--- a/frontend/src/app/data/source-view/episode-preview/episode-preview.component.html
+++ b/frontend/src/app/data/source-view/episode-preview/episode-preview.component.html
@@ -7,9 +7,16 @@
         </a>
     </div>
     <div class="card-body">
-        <p *ngIf="episode.summary">{{episode.summary}}</p>
+        <p class="block">
+            <span *ngIf="episode.summary; else noSummary">
+                {{episode.summary}}
+            </span>
+            <ng-template #noSummary>
+                <i>No summary.</i>
+            </ng-template>
+        </p>
 
-        <ul class="inline-list no-delimiter">
+        <ul class="block inline-list no-delimiter" *ngIf="episode.categories.length">
             <li *ngFor="let category of episode.categories"
                 class="inline-list-item">
                 <span class="badge rounded-pill text-bg-secondary">
@@ -18,7 +25,7 @@
             </li>
         </ul>
 
-        <dl *ngIf="hasEntities(episode)">
+        <dl class="block" *ngIf="hasEntities(episode)">
             <dt>Agents</dt>
             <dd *ngIf="episode.agents.length > 0; else noAgents" class="ms-4">
                 <ul class="inline-list">

--- a/frontend/src/app/data/source-view/episode-preview/episode-preview.component.scss
+++ b/frontend/src/app/data/source-view/episode-preview/episode-preview.component.scss
@@ -1,3 +1,7 @@
 .icon-link.text-reset {
     text-decoration-color: inherit !important;
 }
+
+.block:last-child {
+    margin-bottom: 0;
+}

--- a/frontend/src/app/data/source-view/episode-preview/episode-preview.component.spec.ts
+++ b/frontend/src/app/data/source-view/episode-preview/episode-preview.component.spec.ts
@@ -17,7 +17,7 @@ describe('EpisodePreviewComponent', () => {
         component.episode = {
             id: '1',
             name: 'Test',
-            description: '',
+            categories: [],
             summary: 'Some stuff happens.',
             book: '',
             chapter: '1',

--- a/frontend/src/app/data/source-view/source-view.component.html
+++ b/frontend/src/app/data/source-view/source-view.component.html
@@ -30,7 +30,7 @@
         </div>
     </div>
 
-    <h2 class="mb-4">Episodes</h2>
+    <h2 class="mb-4">Epistolary episodes</h2>
 
     <lc-episode-preview *ngFor="let episode of data.source.episodes"
         [episode]="episode" />

--- a/frontend/src/app/data/source-view/source-view.graphql
+++ b/frontend/src/app/data/source-view/source-view.graphql
@@ -23,23 +23,31 @@ query ViewSource($id: ID!) {
             }
             page
             agents {
-                id
-                name
-                isGroup
-                identified
+                agent {
+                    id
+                    name
+                    isGroup
+                    identified
+                }
             }
             gifts {
-                id
-                name
+                gift {
+                    id
+                    name
+                }
             }
             letters {
-                id
-                name
+                letter {
+                    id
+                    name
+                }
             }
             spaces {
-                id
-                name
-                hasIdentifiableFeatures
+                space {
+                    id
+                    name
+                    hasIdentifiableFeatures
+                }
             }
         }
         contributors {

--- a/frontend/src/app/data/source-view/source-view.graphql
+++ b/frontend/src/app/data/source-view/source-view.graphql
@@ -23,6 +23,7 @@ query ViewSource($id: ID!) {
             }
             page
             agents {
+                id
                 agent {
                     id
                     name
@@ -31,18 +32,21 @@ query ViewSource($id: ID!) {
                 }
             }
             gifts {
+                id
                 gift {
                     id
                     name
                 }
             }
             letters {
+                id
                 letter {
                     id
                     name
                 }
             }
             spaces {
+                id
                 space {
                     id
                     name

--- a/frontend/src/app/data/source-view/source-view.graphql
+++ b/frontend/src/app/data/source-view/source-view.graphql
@@ -10,8 +10,11 @@ query ViewSource($id: ID!) {
         episodes {
             id
             name
-            description
             summary
+            categories {
+                id
+                name
+            }
             book
             chapter
             contributors {

--- a/frontend/src/app/shared/labels.ts
+++ b/frontend/src/app/shared/labels.ts
@@ -1,0 +1,7 @@
+import { SourceMention } from "generated/graphql";
+
+export const sourceMentionLabels: Record<SourceMention, string> = {
+    [SourceMention.Direct]: 'directly mentioned',
+    [SourceMention.Implied]: 'implied',
+    [SourceMention.UpForDebate]: 'up for debate',
+};

--- a/frontend/src/app/shared/sentence-case.pipe.spec.ts
+++ b/frontend/src/app/shared/sentence-case.pipe.spec.ts
@@ -1,0 +1,22 @@
+import { SentenceCasePipe } from './sentence-case.pipe';
+
+describe('SentenceCasePipe', () => {
+    it('create an instance', () => {
+        const pipe = new SentenceCasePipe();
+        expect(pipe).toBeTruthy();
+    });
+
+    it('transforms strings to sentence case', () => {
+        const pipe = new SentenceCasePipe();
+
+        const testCases: Array<[string, string]> = [
+            ['abc', 'Abc'],
+            ['a', 'A'],
+            ['', ''],
+        ];
+
+        for (const [input, output] of testCases) {
+            expect(pipe.transform(input)).toEqual(output);
+        }
+    });
+});

--- a/frontend/src/app/shared/sentence-case.pipe.ts
+++ b/frontend/src/app/shared/sentence-case.pipe.ts
@@ -1,0 +1,12 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+@Pipe({
+    name: 'sentenceCase'
+})
+export class SentenceCasePipe implements PipeTransform {
+
+    transform(value: string): string {
+        return value.slice(0, 1).toUpperCase() + value.slice(1);
+    }
+
+}

--- a/frontend/src/app/shared/shared.module.ts
+++ b/frontend/src/app/shared/shared.module.ts
@@ -15,6 +15,7 @@ import { ContributorsComponent } from './contributors/contributors.component';
 import { CollapsibleCardComponent } from './collapsible-card/collapsible-card.component';
 import { OrderButtonGroupComponent } from './order-button-group/order-button-group.component';
 import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
+import { SentenceCasePipe } from './sentence-case.pipe';
 
 
 
@@ -28,6 +29,7 @@ import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
         ContributorsComponent,
         CollapsibleCardComponent,
         OrderButtonGroupComponent,
+        SentenceCasePipe,
     ],
     imports: [
         CommonModule,
@@ -52,6 +54,7 @@ import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
         ContributorsComponent,
         CollapsibleCardComponent,
         OrderButtonGroupComponent,
+        SentenceCasePipe,
         CommonModule,
         BrowserModule,
         BrowserAnimationsModule,

--- a/frontend/src/styles.scss
+++ b/frontend/src/styles.scss
@@ -30,6 +30,12 @@
     }
 }
 
+.inline-list.no-delimiter {
+    & > .inline-list-item:not(:last-child)::after {
+        content: "\00A0";
+    }
+}
+
 .subform-header {
     margin-top: 1.5rem;
 }


### PR DESCRIPTION
Adds information to the data views that could be edited in the form but was not displayed. Close #176 

I think this comprises:
- The episode preview now shows tagged labels
- Agent view explicitly shows individual/group status
- Agent view explicitly states if an agent has no attached historical figures (instead of hiding the section, which was less clear)
- Episode view shows the location (i.e. book/chapter/page) in the source text
- Cross-references between episodes and agents/gifts/letters/locations include the source mention status, notes, and designators.