### PR TITLE
label select redesign

### DIFF
--- a/frontend/src/app/data-entry/episode-form/episode-contents-form/episode-contents-form.component.html
+++ b/frontend/src/app/data-entry/episode-form/episode-contents-form/episode-contents-form.component.html
@@ -24,11 +24,8 @@
         <p class="form-text">
             Pick one or more labels that describe this episode.
         </p>
-        <lc-single-multi-select
-            [formControl]="form.controls.categories"
-            [options]="episodeCategories"
-            [multiple]="true"
-            placeholder="Select episode labels"
-        />
+
+        <lc-label-select [labels]="episodeCategories"
+            [formControl]="form.controls.categories" />
     </fieldset>
 </form>

--- a/frontend/src/app/data-entry/shared/data-entry-shared.module.ts
+++ b/frontend/src/app/data-entry/shared/data-entry-shared.module.ts
@@ -7,6 +7,7 @@ import { DeleteEntityButtonComponent } from "./delete-entity-button/delete-entit
 import { FormStatusComponent } from "./form-status/form-status.component";
 import { EpisodeLinkFormComponent } from "./episode-link-form/episode-link-form.component";
 import { SingleMultiSelectComponent } from "./single-multi-select/single-multi-select.component";
+import { LabelSelectComponent } from './label-select/label-select.component';
 
 @NgModule({
     declarations: [
@@ -17,6 +18,7 @@ import { SingleMultiSelectComponent } from "./single-multi-select/single-multi-s
         FormStatusComponent,
         EpisodeLinkFormComponent,
         SingleMultiSelectComponent,
+        LabelSelectComponent,
     ],
     imports: [SharedModule],
     exports: [
@@ -27,6 +29,7 @@ import { SingleMultiSelectComponent } from "./single-multi-select/single-multi-s
         FormStatusComponent,
         EpisodeLinkFormComponent,
         SingleMultiSelectComponent,
+        LabelSelectComponent,
     ],
 })
 export class DataEntrySharedModule {}

--- a/frontend/src/app/data-entry/shared/label-select/label-select.component.html
+++ b/frontend/src/app/data-entry/shared/label-select/label-select.component.html
@@ -1,4 +1,4 @@
-<ul class="d-flex d-wrap list-unstyled" *ngIf="labels.length; else noLabels">
+<ul class="d-flex flex-wrap list-unstyled" *ngIf="labels.length; else noLabels">
     <li *ngFor="let label of labels" class="p-1">
         <button class="btn btn-tag"
             [class]="isSelected(label) ? 'btn-secondary' : 'btn-light'"

--- a/frontend/src/app/data-entry/shared/label-select/label-select.component.html
+++ b/frontend/src/app/data-entry/shared/label-select/label-select.component.html
@@ -5,7 +5,6 @@
             [attr.aria-selected]="isSelected(label)"
             type="button"
             (click)="toggle(label)"
-            (blur)="blur()"
             [ngbTooltip]="label.description">
             <lc-icon [icon]="isSelected(label) ? 'check-square' : 'square'"
                 class="me-1" />

--- a/frontend/src/app/data-entry/shared/label-select/label-select.component.html
+++ b/frontend/src/app/data-entry/shared/label-select/label-select.component.html
@@ -1,0 +1,21 @@
+<ul class="d-flex d-wrap list-unstyled" *ngIf="labels.length; else noLabels">
+    <li *ngFor="let label of labels" class="p-1">
+        <button class="btn btn-tag"
+            [class]="isSelected(label) ? 'btn-secondary' : 'btn-light'"
+            [attr.aria-selected]="isSelected(label)"
+            type="button"
+            (click)="toggle(label)"
+            (blur)="blur()"
+            [ngbTooltip]="label.description">
+            <lc-icon [icon]="isSelected(label) ? 'check-square' : 'square'"
+                class="me-1" />
+            {{label.label}}
+        </button>
+    </li>
+</ul>
+
+<ng-template #noLabels>
+    <p>
+        <i>No labels available.</i>
+    </p>
+</ng-template>

--- a/frontend/src/app/data-entry/shared/label-select/label-select.component.scss
+++ b/frontend/src/app/data-entry/shared/label-select/label-select.component.scss
@@ -1,0 +1,3 @@
+.btn-tag {
+    border-radius: 1.5em;
+}

--- a/frontend/src/app/data-entry/shared/label-select/label-select.component.spec.ts
+++ b/frontend/src/app/data-entry/shared/label-select/label-select.component.spec.ts
@@ -1,0 +1,27 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { LabelSelectComponent } from './label-select.component';
+import { SharedTestingModule } from '@shared/shared-testing.module';
+
+describe('LabelSelectComponent', () => {
+    let component: LabelSelectComponent;
+    let fixture: ComponentFixture<LabelSelectComponent>;
+
+    beforeEach(() => {
+        TestBed.configureTestingModule({
+            declarations: [LabelSelectComponent],
+            imports: [SharedTestingModule],
+        });
+        fixture = TestBed.createComponent(LabelSelectComponent);
+        component = fixture.componentInstance;
+        component.labels = [
+            { value: '1', label: 'Test' },
+            { value: '2', label: 'Another test' },
+        ];
+        fixture.detectChanges();
+    });
+
+    it('should create', () => {
+        expect(component).toBeTruthy();
+    });
+});

--- a/frontend/src/app/data-entry/shared/label-select/label-select.component.ts
+++ b/frontend/src/app/data-entry/shared/label-select/label-select.component.ts
@@ -1,4 +1,4 @@
-import { Component, forwardRef, Input } from '@angular/core';
+import { Component, forwardRef, HostListener, Input } from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 
 type Label = { value: string, label: string, description?: string };
@@ -36,7 +36,8 @@ export class LabelSelectComponent implements ControlValueAccessor {
         this.onChange?.(this.value);
     }
 
-    blur() {
+    @HostListener('focusout')
+    onFocusOut(): void {
         this.onTouched?.();
     }
 

--- a/frontend/src/app/data-entry/shared/label-select/label-select.component.ts
+++ b/frontend/src/app/data-entry/shared/label-select/label-select.component.ts
@@ -1,7 +1,6 @@
 import { Component, forwardRef, HostListener, Input } from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
-
-type Label = { value: string, label: string, description?: string };
+import { MultiselectOption } from '../multiselect/multiselect.component';
 
 @Component({
     selector: 'lc-label-select',
@@ -16,18 +15,18 @@ type Label = { value: string, label: string, description?: string };
     ],
 })
 export class LabelSelectComponent implements ControlValueAccessor {
-    @Input({ required: true }) labels!: Label[];
+    @Input({ required: true }) labels!: MultiselectOption[];
 
     value: string[] = [];
 
     private onChange?: (value: string[]) => any;
     private onTouched?: () => any;
 
-    isSelected(label: Label): boolean {
+    isSelected(label: MultiselectOption): boolean {
         return this.value.includes(label.value);
     }
 
-    toggle(label: Label): void {
+    toggle(label: MultiselectOption): void {
         if (this.isSelected(label)) {
             this.value = this.value.filter(i => i !== label.value);
         } else {

--- a/frontend/src/app/data-entry/shared/label-select/label-select.component.ts
+++ b/frontend/src/app/data-entry/shared/label-select/label-select.component.ts
@@ -1,0 +1,55 @@
+import { Component, forwardRef, Input } from '@angular/core';
+import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
+
+type Label = { value: string, label: string, description?: string };
+
+@Component({
+    selector: 'lc-label-select',
+    templateUrl: './label-select.component.html',
+    styleUrls: ['./label-select.component.scss'],
+    providers: [
+        {
+            provide: NG_VALUE_ACCESSOR,
+            useExisting: forwardRef(() => LabelSelectComponent),
+            multi: true,
+        },
+    ],
+})
+export class LabelSelectComponent implements ControlValueAccessor {
+    @Input({ required: true }) labels!: Label[];
+
+    value: string[] = [];
+
+    private onChange?: (value: string[]) => any;
+    private onTouched?: () => any;
+
+    isSelected(label: Label): boolean {
+        return this.value.includes(label.value);
+    }
+
+    toggle(label: Label): void {
+        if (this.isSelected(label)) {
+            this.value = this.value.filter(i => i !== label.value);
+        } else {
+            this.value.push(label.value);
+        }
+        this.onChange?.(this.value);
+    }
+
+    blur() {
+        this.onTouched?.();
+    }
+
+    writeValue(obj: string[]): void {
+        this.value = obj;
+        this.onChange?.(this.value);
+    }
+
+    registerOnChange(fn: () => any): void {
+        this.onChange = fn;
+    }
+
+    registerOnTouched(fn: () => any): void {
+        this.onTouched = fn;
+    }
+}


### PR DESCRIPTION
Changes the look/behaviour of selecting episode labels. Screenshot:

![screenshot of label input showing a list of toggle buttons](https://github.com/user-attachments/assets/5e59d178-470d-4208-9ee0-a8d827a5746d)

The main reason was that the old input used a dropdown which made it hard to display label descriptions. (I don't really want to add a popup inside another popup.) I added those as tooltips now, but if the researchers want to enter longer descriptions, we could turn them into clickable popups.

Also: this version makes it a bit easier to scan over the list of labels and click the ones that apply.


