### PR TITLE
Add PreviewNotificationComponent

### DIFF
--- a/frontend/src/app/data/agent-view/agent-view.component.html
+++ b/frontend/src/app/data/agent-view/agent-view.component.html
@@ -13,6 +13,8 @@
 
         <lc-contributors [contributors]="agent.contributors" />
 
+        <lc-preview-notification *ngIf="!agent.source.isPublic" />
+
         <section class="mt-5">
             <h2>Description</h2>
 

--- a/frontend/src/app/data/agent-view/agent-view.graphql
+++ b/frontend/src/app/data/agent-view/agent-view.graphql
@@ -9,6 +9,7 @@ query ViewAgent($id: ID!) {
     source {
         id
         name
+        isPublic
     }
     episodes {
         id

--- a/frontend/src/app/data/data.module.ts
+++ b/frontend/src/app/data/data.module.ts
@@ -13,6 +13,7 @@ import { EpisodePreviewComponent } from './source-view/episode-preview/episode-p
 import { EpisodeListComponent } from './episode-list/episode-list.component';
 import { SourceListComponent } from './source-list/source-list.component';
 import { SearchBarComponent } from './shared/search-bar/search-bar.component';
+import { PreviewNotificationComponent } from './shared/preview-notification/preview-notification.component';
 
 
 
@@ -31,6 +32,7 @@ import { SearchBarComponent } from './shared/search-bar/search-bar.component';
         SourceListComponent,
         EpisodeListComponent,
         SearchBarComponent,
+        PreviewNotificationComponent,
     ],
     imports: [
         SharedModule,

--- a/frontend/src/app/data/episode-view/episode-view.component.html
+++ b/frontend/src/app/data/episode-view/episode-view.component.html
@@ -25,6 +25,8 @@
 
     <lc-contributors [contributors]="episode.contributors" />
 
+    <lc-preview-notification *ngIf="!episode.source.isPublic" />
+
     <h2 class="mt-5">Source text</h2>
 
     <dl>

--- a/frontend/src/app/data/episode-view/episode-view.graphql
+++ b/frontend/src/app/data/episode-view/episode-view.graphql
@@ -6,6 +6,7 @@ query ViewEpisode($id: ID!) {
     source {
         id
         name
+        isPublic
     }
     book
     chapter

--- a/frontend/src/app/data/gift-view/gift-view.component.html
+++ b/frontend/src/app/data/gift-view/gift-view.component.html
@@ -12,7 +12,9 @@
 
         <lc-contributors [contributors]="gift.contributors" />
 
-        <section class="mb-5">
+        <lc-preview-notification *ngIf="!gift.source.isPublic" />
+
+        <section class="mb-5 mt-4">
             <h2>Source text</h2>
 
             <p>

--- a/frontend/src/app/data/gift-view/gift-view.graphql
+++ b/frontend/src/app/data/gift-view/gift-view.graphql
@@ -7,6 +7,7 @@ query ViewGift($id: ID!) {
     source {
         id
         name
+        isPublic
     }
     episodes {
         id

--- a/frontend/src/app/data/letter-view/letter-view.component.html
+++ b/frontend/src/app/data/letter-view/letter-view.component.html
@@ -12,7 +12,9 @@
 
         <lc-contributors [contributors]="letter.contributors" />
 
-        <section class="mb-5">
+        <lc-preview-notification *ngIf="!letter.source.isPublic" />
+
+        <section class="mt-4 mb-5">
             <h2>Source text</h2>
 
             <p>

--- a/frontend/src/app/data/letter-view/letter-view.graphql
+++ b/frontend/src/app/data/letter-view/letter-view.graphql
@@ -7,6 +7,7 @@ query ViewLetter($id: ID!) {
     source {
         id
         name
+        isPublic
     }
     episodes {
         id

--- a/frontend/src/app/data/location-view/location-view.component.html
+++ b/frontend/src/app/data/location-view/location-view.component.html
@@ -12,6 +12,8 @@
 
         <lc-contributors [contributors]="location.contributors" />
 
+        <lc-preview-notification *ngIf="!location.source.isPublic" />
+
         <section class="mt-4 mb-5">
             <h2>Source text</h2>
 

--- a/frontend/src/app/data/location-view/location-view.graphql
+++ b/frontend/src/app/data/location-view/location-view.graphql
@@ -7,6 +7,7 @@ query ViewLocation($id: ID!) {
     source {
       id
       name
+      isPublic
     }
     episodes {
       id

--- a/frontend/src/app/data/shared/preview-notification/preview-notification.component.html
+++ b/frontend/src/app/data/shared/preview-notification/preview-notification.component.html
@@ -1,0 +1,3 @@
+<ngb-alert class="mt-3 mb-0" type="info">
+    This page is in preview mode, since the source text it belongs to is marked as non-public. Only contributing users who are allowed to edit this page are able to see it.
+</ngb-alert>

--- a/frontend/src/app/data/shared/preview-notification/preview-notification.component.spec.ts
+++ b/frontend/src/app/data/shared/preview-notification/preview-notification.component.spec.ts
@@ -1,0 +1,21 @@
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+
+import { PreviewNotificationComponent } from "./preview-notification.component";
+
+describe("PreviewNotificationComponent", () => {
+    let component: PreviewNotificationComponent;
+    let fixture: ComponentFixture<PreviewNotificationComponent>;
+
+    beforeEach(() => {
+        TestBed.configureTestingModule({
+            declarations: [PreviewNotificationComponent],
+        });
+        fixture = TestBed.createComponent(PreviewNotificationComponent);
+        component = fixture.componentInstance;
+        fixture.detectChanges();
+    });
+
+    it("should create", () => {
+        expect(component).toBeTruthy();
+    });
+});

--- a/frontend/src/app/data/shared/preview-notification/preview-notification.component.ts
+++ b/frontend/src/app/data/shared/preview-notification/preview-notification.component.ts
@@ -1,0 +1,8 @@
+import { Component } from "@angular/core";
+
+@Component({
+    selector: "lc-preview-notification",
+    templateUrl: "./preview-notification.component.html",
+    styleUrls: ["./preview-notification.component.scss"],
+})
+export class PreviewNotificationComponent {}

--- a/frontend/src/app/data/source-view/source-view.component.html
+++ b/frontend/src/app/data/source-view/source-view.component.html
@@ -19,6 +19,8 @@
 
     <lc-contributors [contributors]="source.contributors" />
 
+    <lc-preview-notification *ngIf="!source.isPublic" />
+
     <div class="card mb-4 mt-4">
         <div class="card-body">
             <h2 class="h5 card-title">Bibliographical information</h2>

--- a/frontend/src/app/data/source-view/source-view.graphql
+++ b/frontend/src/app/data/source-view/source-view.graphql
@@ -3,6 +3,7 @@ query ViewSource($id: ID!) {
         id
         name
         editable
+        isPublic
         editionAuthor
         editionTitle
         medievalAuthor


### PR DESCRIPTION
This is a bonus on top of #197.

Contributors can click the 'View on public interface' button for sources/agents/episodes/etc. to check how visitors would be able to view them. However, these pages are not reachable for non-contributing users, and they will not show up in the browsing interface (`/data`), which might be confusing.

This PR adds an alert bar (`ngbAlert`) indicating that the browse page in question is visible to contributors only and is not visible to general users visiting the browsing interface.