### PR TITLE
Feature/download designators

### DIFF
--- a/backend/event/admin.py
+++ b/backend/event/admin.py
@@ -1,13 +1,15 @@
 from django.contrib import admin
 from . import models
 from core import admin as core_admin
+from django.http.response import FileResponse
+import io
+from event.export_designators import export_designators
 
 
 @admin.register(models.EpisodeCategory)
 class EpisodeCategoryAdmin(admin.ModelAdmin):
     list_display = ["name", "description"]
     search_fields = ["name", "description"]
-
 
 class EpisodeAgentAdmin(admin.StackedInline):
     model = models.EpisodeAgent
@@ -89,6 +91,19 @@ class EpisodeAdmin(core_admin.EntityDescriptionAdmin, admin.ModelAdmin):
         EpisodeLetterAdmin,
         EpisodeSpaceAdmin,
     ]
+
+    actions = ['download_designators']
+
+    @admin.action(description='Download designators from selected episodes')
+    def download_designators(self, request, queryset):
+        stream = io.StringIO()
+        export_designators(queryset, stream)
+        bytes_stream = io.BytesIO(stream.getvalue().encode())
+        return FileResponse(
+            bytes_stream,
+            filename='designators.csv',
+            as_attachment=True
+        )
 
 
 @admin.register(models.Series)

--- a/backend/event/admin.py
+++ b/backend/event/admin.py
@@ -98,7 +98,8 @@ class EpisodeAdmin(core_admin.EntityDescriptionAdmin, admin.ModelAdmin):
     def download_designators(self, request, queryset):
         stream = io.StringIO()
         export_designators(queryset, stream)
-        bytes_stream = io.BytesIO(stream.getvalue().encode())
+        # convert to binary stream; use utf-16 encoding for MS Excel
+        bytes_stream = io.BytesIO(stream.getvalue().encode(encoding='utf-16'))
         return FileResponse(
             bytes_stream,
             filename='designators.csv',

--- a/backend/event/export_designators.py
+++ b/backend/event/export_designators.py
@@ -1,0 +1,17 @@
+import csv
+from django.db.models import QuerySet
+from collections import Counter
+from itertools import chain
+
+from event.models import Episode
+
+def count_designators(episodes: QuerySet[Episode]):
+    return Counter(chain(*(episode.designators for episode in episodes)))
+
+
+def export_designators(episodes: QuerySet[Episode], f):
+    writer = csv.DictWriter(f, ['designator', 'count'])
+    writer.writeheader()
+    data = count_designators(episodes)
+    for designator, count in data.items():
+        writer.writerow({'designator': designator, 'count': count})

--- a/backend/event/tests/test_aggregate_designators.py
+++ b/backend/event/tests/test_aggregate_designators.py
@@ -1,0 +1,22 @@
+import pytest
+
+from event.models import Episode
+from event.export_designators import count_designators
+
+@pytest.fixture()
+def episode_designators(episode: Episode):
+    episode.designators = ['test', 'testing']
+    episode.save()
+
+@pytest.fixture()
+def episode_2_designators(episode_2: Episode):
+    episode_2.designators = ['test']
+    episode_2.save()
+
+def test_count_designators(episode, episode_2, episode_designators, episode_2_designators):
+    episodes = Episode.objects.all()
+    counts = count_designators(episodes)
+    assert counts['test'] == 2
+    assert counts['testing'] == 1
+
+


### PR DESCRIPTION
Adds the option to download a list of all designators from the admin interface.

Designators are exported to CSV so they can be opened in Excel. The file also includes the number of episodes per designator which seemed useful.