### PR TITLE
Feature/long entity lists

### DIFF
--- a/frontend/src/app/data-entry/episode-form/episode-entities-form/episode-entities-form.component.html
+++ b/frontend/src/app/data-entry/episode-form/episode-entities-form/episode-entities-form.component.html
@@ -30,7 +30,11 @@
                     Add {{entityName}}
                 </button>
                 <div ngbDropdownMenu [attr.aria-labelledby]="dropdownToggleID">
-                    <button ngbDropdownItem (click)="createEntity$.next()">
+                    <input type="text" class="form-control search-bar"
+                        placeholder="Search for {{entityName}}s"
+                        [formControl]="searchControl"
+                        [attr.aria-label]="'Search for ' + entityName + 's'" />
+                    <button *ngIf="!searchControl.value" ngbDropdownItem (click)="createEntity$.next()">
                         <lc-icon [icon]="actionIcons.create" />
                         Create new {{entityName}}
                     </button>
@@ -38,6 +42,9 @@
                         ngbDropdownItem (click)="addEntity$.next(entity.id); dropdownToggle.focus()">
                         {{entity.name}}
                     </button>
+                    <ng-container *ngIf="searchControl.value && (availableEntities$ | async)?.length === 0">
+                        <button ngbDropdownItem disabled>No results found.</button>
+                    </ng-container>
                 </div>
             </div>
         </div>

--- a/frontend/src/app/data-entry/episode-form/episode-entities-form/episode-entities-form.component.html
+++ b/frontend/src/app/data-entry/episode-form/episode-entities-form/episode-entities-form.component.html
@@ -30,13 +30,13 @@
                     Add {{entityName}}
                 </button>
                 <div ngbDropdownMenu [attr.aria-labelledby]="dropdownToggleID">
-                    <button *ngFor="let entity of (availableEntities$ | async)"
-                        ngbDropdownItem (click)="addEntity$.next(entity.id); dropdownToggle.focus()">
-                        {{entity.name}}
-                    </button>
                     <button ngbDropdownItem (click)="createEntity$.next()">
                         <lc-icon [icon]="actionIcons.create" />
                         Create new {{entityName}}
+                    </button>
+                    <button *ngFor="let entity of (availableEntities$ | async)"
+                        ngbDropdownItem (click)="addEntity$.next(entity.id); dropdownToggle.focus()">
+                        {{entity.name}}
                     </button>
                 </div>
             </div>

--- a/frontend/src/app/data-entry/episode-form/episode-entities-form/episode-entities-form.component.html
+++ b/frontend/src/app/data-entry/episode-form/episode-entities-form/episode-entities-form.component.html
@@ -1,16 +1,26 @@
 <ng-container *ngIf="data$ | async as data">
     <ng-container *ngIf="data.episode">
-        <ng-container *ngIf="(linkedEntities$ | async)?.length; else noEntities">
-            <p>The following {{entityName}}s are involved in this episode:</p>
+        <ng-container
+            *ngIf="(linkedEntities$ | async)?.length; else noEntities"
+        >
+            <p>The following {{ entityName }}s are involved in this episode:</p>
             <ul class="list-unstyled vstack gap-4">
                 <li *ngFor="let entity of linkedEntities$ | async">
-                    <lc-episode-link-form [entityType]="entityType" linkTo="entity"
-                            [entityID]="entity.id"
-                            [episodeID]="data.episode.id">
-                        <button removeControl class="btn btn-danger"
-                            [attr.aria-label]="'remove ' + entityName + ': ' + entity.name"
+                    <lc-episode-link-form
+                        [entityType]="entityType"
+                        linkTo="entity"
+                        [entityID]="entity.id"
+                        [episodeID]="data.episode.id"
+                    >
+                        <button
+                            removeControl
+                            class="btn btn-danger"
+                            [attr.aria-label]="
+                                'remove ' + entityName + ': ' + entity.name
+                            "
                             [ngbTooltip]="'remove this ' + entityName"
-                            (click)="removeEntity$.next(entity.id)">
+                            (click)="removeEntity$.next(entity.id)"
+                        >
                             <lc-icon [icon]="actionIcons.remove" />
                         </button>
                     </lc-episode-link-form>
@@ -18,39 +28,78 @@
             </ul>
         </ng-container>
         <ng-template #noEntities>
-            <p>
-                No {{entityName}}s have been added to this episode.
-            </p>
+            <p>No {{ entityName }}s have been added to this episode.</p>
         </ng-template>
 
         <div class="mt-4 mb-4">
             <div ngbDropdown>
-                <button type="button" class="btn btn-primary" #dropdownToggle
-                    [attr.id]="dropdownToggleID" ngbDropdownToggle>
-                    Add {{entityName}}
+                <button
+                    type="button"
+                    class="btn btn-primary"
+                    #dropdownToggle
+                    [attr.id]="dropdownToggleID"
+                    ngbDropdownToggle
+                >
+                    Add {{ entityName }}
                 </button>
                 <div ngbDropdownMenu [attr.aria-labelledby]="dropdownToggleID">
-                    <input type="text" class="form-control search-bar"
-                        placeholder="Search for {{entityName}}s"
-                        [formControl]="searchControl"
-                        [attr.aria-label]="'Search for ' + entityName + 's'" />
-                    <button *ngIf="!searchControl.value" ngbDropdownItem (click)="createEntity$.next()">
+                    <button ngbDropdownItem (click)="createEntity$.next()">
                         <lc-icon [icon]="actionIcons.create" />
-                        Create new {{entityName}}
+                        Create new {{ entityName }}
                     </button>
-                    <button *ngFor="let entity of (availableEntities$ | async)"
-                        ngbDropdownItem (click)="addEntity$.next(entity.id); dropdownToggle.focus()">
-                        {{entity.name}}
+                    <hr class="dropdown-divider mb-3" />
+                    <input
+                        type="search"
+                        class="form-control search-bar"
+                        placeholder="Search for {{ entityName }}s"
+                        [formControl]="searchControl"
+                        [attr.aria-describedby]="
+                            'search-info-{{dropdownToggleID}}'
+                        "
+                        [attr.aria-label]="'Search for ' + entityName + 's'"
+                    />
+                    <small
+                        ngbDropdownItem
+                        [id]="'search-info-{{dropdownToggleID}}'"
+                        class="fst-italic text"
+                        disabled
+                        >Results will be updated as you type.</small
+                    >
+                    <button
+                        *ngFor="let entity of availableEntities$ | async"
+                        ngbDropdownItem
+                        (click)="
+                            addEntity$.next(entity.id); dropdownToggle.focus()
+                        "
+                    >
+                        {{ entity.name }}
                     </button>
-                    <ng-container *ngIf="searchControl.value && (availableEntities$ | async)?.length === 0">
-                        <button ngbDropdownItem disabled>No results found.</button>
-                    </ng-container>
+                    <div
+                        ngbDropdownItem
+                        class="text-body-secondary"
+                        aria-live="assertive"
+                        aria-atomic="true"
+                        disabled
+                    >
+                        <p
+                            *ngIf="
+                                searchControl.value &&
+                                (availableEntities$ | async)?.length === 0
+                            "
+                            class="text mb-2"
+                        >
+                            No results found.
+                        </p>
+                    </div>
                 </div>
             </div>
         </div>
 
-        <lc-create-entity [entityType]="entityType" [create]="createEntity$"
+        <lc-create-entity
+            [entityType]="entityType"
+            [create]="createEntity$"
             [sourceID]="data.episode.source.id"
-            [episodeID]="data.episode.id" />
+            [episodeID]="data.episode.id"
+        />
     </ng-container>
 </ng-container>

--- a/frontend/src/app/data-entry/episode-form/episode-entities-form/episode-entities-form.component.scss
+++ b/frontend/src/app/data-entry/episode-form/episode-entities-form/episode-entities-form.component.scss
@@ -1,0 +1,4 @@
+.search-bar {
+    margin: var(--bs-dropdown-item-padding-y) var(--bs-dropdown-item-padding-x);
+    width: auto;
+}

--- a/frontend/src/app/data-entry/episode-form/episode-entities-form/episode-entities-form.component.ts
+++ b/frontend/src/app/data-entry/episode-form/episode-entities-form/episode-entities-form.component.ts
@@ -1,5 +1,5 @@
 import { Component, Input, OnChanges, OnDestroy, SimpleChanges } from "@angular/core";
-import { combineLatest, map, Observable, Observer, startWith, Subject, switchMap, tap, withLatestFrom } from "rxjs";
+import { combineLatest, map, Observable, Observer, startWith, Subject, switchMap, tap, withLatestFrom, shareReplay } from "rxjs";
 import { entityTypeNames, formStatusSubject } from "../../shared/utils";
 import { actionIcons } from "@shared/icons";
 import { MutationResult } from "apollo-angular";
@@ -48,6 +48,7 @@ export class EpisodeEntitiesFormComponent implements OnChanges, OnDestroy {
     });
     entitySearch$ = this.searchControl.valueChanges.pipe(
         startWith(""),
+        shareReplay(1),
     );
 
     addEntity$ = new Subject<string>();
@@ -109,8 +110,8 @@ export class EpisodeEntitiesFormComponent implements OnChanges, OnDestroy {
             [Entity.Gift]: 'gifts',
             [Entity.Letter]: 'letters',
             [Entity.Space]: 'spaces',
-        }
-        return keys[this.entityType]
+        };
+        return keys[this.entityType];
     }
 
     get entityTypeName(): EntityTypeName {
@@ -119,7 +120,7 @@ export class EpisodeEntitiesFormComponent implements OnChanges, OnDestroy {
             [Entity.Gift]: 'GiftDescriptionType',
             [Entity.Letter]: 'LetterDescriptionType',
             [Entity.Space]: 'SpaceDescriptionType',
-        }
+        };
         return types[this.entityType];
     }
 
@@ -161,7 +162,7 @@ export class EpisodeEntitiesFormComponent implements OnChanges, OnDestroy {
         this.removeMutation.mutate(data, {
             update: cache => this.updateCacheOnAddRemove(episodeID, entityID, cache)
         }).pipe(
-        ).subscribe(this.mutationRequestObserver)
+        ).subscribe(this.mutationRequestObserver);
     }
 
     onSuccess() {
@@ -174,7 +175,7 @@ export class EpisodeEntitiesFormComponent implements OnChanges, OnDestroy {
             header: `Adding ${this.entityName} failed`,
             body: `Could not add ${this.entityName}`,
             type: 'danger',
-        })
+        });
         this.status$.next('error');
     }
 

--- a/frontend/src/app/data-entry/episode-form/episode-entities-form/episode-entities-form.component.ts
+++ b/frontend/src/app/data-entry/episode-form/episode-entities-form/episode-entities-form.component.ts
@@ -1,8 +1,7 @@
 import { Component, Input, OnChanges, OnDestroy, SimpleChanges } from "@angular/core";
-import { combineLatest, map, Observable, Observer, startWith, Subject, switchMap, tap, withLatestFrom, shareReplay } from "rxjs";
+import { combineLatest, map, Observable, startWith, Subject, switchMap, withLatestFrom, shareReplay } from "rxjs";
 import { entityTypeNames, formStatusSubject } from "../../shared/utils";
 import { actionIcons } from "@shared/icons";
-import { MutationResult } from "apollo-angular";
 import { FormService } from "../../shared/form.service";
 import {
     CreateEpisodeEntityLinkInput,
@@ -161,7 +160,7 @@ export class EpisodeEntitiesFormComponent implements OnChanges, OnDestroy {
         ).subscribe({
             next: () => this.onSuccess(),
             error: (error) => this.onError(error, 'removeEntity'),
-        })
+        });
     }
 
     onSuccess() {


### PR DESCRIPTION
Closes #187 by:
- moving the "Create new ..." option to the top;
- sorting the available entities alphabetically.

I've added an extra commit that adds a search bar, but I'm not sure whether this is a good idea. I checked the list of [W3C APG patterns](https://www.w3.org/WAI/ARIA/apg/patterns/) but I cannot find a good comparandum. (The editable combobox comes close, but isn't quite the same.) I am happy to drop it if you don't like it. If we do keep it, we should decide on the best way to make this widget more accessible.