### PR TITLE
Override allauth registration email template

### DIFF
--- a/backend/lettercraft/settings.py
+++ b/backend/lettercraft/settings.py
@@ -77,7 +77,9 @@ ROOT_URLCONF = 'lettercraft.urls'
 TEMPLATES = [
     {
         'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'DIRS': [],
+        'DIRS': [
+            os.path.join(BASE_DIR, 'user', 'templates'),
+        ],
         'APP_DIRS': True,
         'OPTIONS': {
             'context_processors': [

--- a/backend/user/templates/account/email/email_confirmation_message.txt
+++ b/backend/user/templates/account/email/email_confirmation_message.txt
@@ -1,0 +1,13 @@
+{% extends "account/email/base_message.txt" %}
+{% load account %}
+{% load i18n %}
+
+{% comment %}
+This overrides the original found at allauth/templates/account/email/email_confirmation_message.txt.
+The user_display variable has been removed to avoid impersonation/abuse.
+{% endcomment %}
+{% block content %}{% autoescape off %}{% blocktrans with site_name=current_site.name site_domain=current_site.domain %}You're receiving this email because your email address was used to register an account on {{ site_domain }}.
+
+To confirm this is correct, go to {{ activate_url }}
+
+If you did not request this, please ignore this email.{% endblocktrans %}{% endautoescape %}{% endblock content %}

--- a/backend/user/templates/account/email/email_confirmation_message.txt
+++ b/backend/user/templates/account/email/email_confirmation_message.txt
@@ -4,10 +4,12 @@
 
 {% comment %}
 This overrides the original found at allauth/templates/account/email/email_confirmation_message.txt.
-The user_display variable has been removed to avoid impersonation/abuse.
+
+The original wording may be taken to suggest that someone else (not the user)
+created an account for the person receiving the email. The updated wording here
+clarifies that the user themselves created the account and avoids potential
+impersonation concerns.
 {% endcomment %}
-{% block content %}{% autoescape off %}{% blocktrans with site_name=current_site.name site_domain=current_site.domain %}You're receiving this email because your email address was used to register an account on {{ site_domain }}.
+{% block content %}{% autoescape off %}{% user_display user as user_display %}{% blocktrans with site_name=current_site.name site_domain=current_site.domain %}You're receiving this email because someone used your email address to register an account with the name "{{ user_display}}" on {{ site_domain }}.
 
-To confirm this is correct, go to {{ activate_url }}
-
-If you did not request this, please ignore this email.{% endblocktrans %}{% endautoescape %}{% endblock content %}
+If this was you and you wish to confirm your email address, go to {{ activate_url }}{% endblocktrans %}{% endautoescape %}{% endblock content %}


### PR DESCRIPTION
Closes #252

To avoid security reports like this in the future, we should update the CookieCutter template as well.