### PR TITLE
Fix: add fields to CaseStudyType

### DIFF
--- a/backend/case_study/types/CaseStudyType.py
+++ b/backend/case_study/types/CaseStudyType.py
@@ -8,6 +8,15 @@ from case_study.models import CaseStudy
 class CaseStudyType(DjangoObjectType):
     class Meta:
         model = CaseStudy
+        fields = [
+            "id",
+            "name",
+            "description",
+            "authors",
+            "date",
+            "content",
+            "sources",
+        ]
 
     @classmethod
     def get_queryset(


### PR DESCRIPTION
Fixes a warning that shows up (at least) when running `pytest`:

<img width="1218" height="104" alt="image" src="https://github.com/user-attachments/assets/b59bd5b5-fe54-401a-ad8d-d7124bc5f2e8" />
