### PR TITLE
Feature/docx export

### DIFF
--- a/backend/download/export_docx.py
+++ b/backend/download/export_docx.py
@@ -29,9 +29,7 @@ def _add_source(data: Dict, document: DocumentObject) -> None:
     document.add_heading(data["name"])
 
     if contributors := data["contributors"]:
-        document.add_paragraph(
-            f"Contributors: {", ".join(contributors)}"
-        )
+        _add_key_value_paragraph("contributors", ", ".join(contributors), document)
 
     if description := data["description"]:
         document.add_paragraph(description)
@@ -46,35 +44,37 @@ def _add_source(data: Dict, document: DocumentObject) -> None:
 
     for key in ["letters", "gifts", "locations"]:
         document.add_heading(key.capitalize(), level=2)
-        for agent in data[key]:
-            _add_entity(agent, document)
+        for entity in data[key]:
+            _add_entity(entity, document)
 
 
 def _add_episode(data: Dict, source_data: Dict, document: DocumentObject) -> None:
     document.add_heading(data["name"], level=3)
 
     if source_ref := _episode_source_ref(data["source_reference"]):
-        document.add_paragraph(source_ref)
+        p = document.add_paragraph()
+        run = p.add_run(source_ref)
+        run.italic = True
 
     if summary := data["summary"]:
         document.add_paragraph(summary)
 
     if labels := data["labels"]:
-        document.add_paragraph(
-            f"Labels: {", ".join(labels)}"
-        )
+        _add_key_value_paragraph("labels", ", ".join(labels), document)
 
     if designators := data["designators"]:
-        document.add_paragraph(
-            f"Designators: {", ".join(designators)}",
-        )
+        _add_key_value_paragraph("designators", ", ".join(designators), document)
 
     for key in ["agents", "letters", "gifts", "locations"]:
         if entities := _episode_entity_names(data, source_data, key):
-            document.add_paragraph()
-            document.add_paragraph(
-                f"{key}: {entities}".capitalize()
-            )
+            _add_key_value_paragraph(key, entities, document)
+
+
+def _add_key_value_paragraph(key: str, value: str, document: DocumentObject):
+    p = document.add_paragraph()
+    head = p.add_run(key.capitalize() + ":")
+    head.bold = True
+    p.add_run(" " + value)
 
 
 def _episode_source_ref(data: Dict) -> str:

--- a/backend/download/export_docx.py
+++ b/backend/download/export_docx.py
@@ -13,15 +13,18 @@ def save_docx(sources: QuerySet[Source], out: TextIOWrapper) -> None:
     data = json_data(sources)
 
     document = Document()
-    _add_preamble(document)
+    _add_preamble(data["metadata"], document)
     for source in data['sources']:
         _add_source(source, document)
 
     document.save(out)
 
 
-def _add_preamble(document: DocumentObject) -> None:
-    document.add_heading("Lettercraft data")
+def _add_preamble(data: Dict, document: DocumentObject) -> None:
+    document.add_heading(f"Lettercraft data")
+    document.add_paragraph(
+        f"Exported from {data["url"]} on {data["date"]}"
+    )
 
 
 def _add_source(data: Dict, document: DocumentObject) -> None:

--- a/backend/download/export_docx.py
+++ b/backend/download/export_docx.py
@@ -1,0 +1,64 @@
+from io import TextIOWrapper
+from typing import Dict
+
+from django.db.models import QuerySet
+from docx import Document
+from docx.document import Document as DocumentObject
+
+from source.models import Source
+from download.export_json import json_data
+
+
+def save_docx(sources: QuerySet[Source], out: TextIOWrapper) -> None:
+    data = json_data(sources)
+
+    document = Document()
+    _add_preamble(document)
+    for source in data['sources']:
+        _add_source(source, document)
+
+    document.save(out)
+
+
+def _add_preamble(document: DocumentObject) -> None:
+    document.add_heading("Lettercraft data")
+
+
+def _add_source(data: Dict, document: DocumentObject) -> None:
+    document.add_page_break()
+    document.add_heading(data["name"])
+
+    if len(data["contributors"]):
+        document.add_paragraph(
+            f"Contributors: {", ".join(data["contributors"])}"
+        )
+
+    if data["description"]:
+        document.add_paragraph(data["description"])
+
+    for episode in data["episodes"]:
+        _add_episode(episode, document)
+
+
+def _add_episode(data: Dict, document: DocumentObject) -> None:
+    document.add_heading(data["name"], level=2)
+
+    source_ref = _episode_source_ref(data["source_reference"])
+    if source_ref:
+        document.add_paragraph(source_ref)
+
+    document.add_paragraph(data["summary"])
+    if len(data["designators"]):
+        document.add_paragraph(
+            f"Designators: {", ".join(data["designators"])}",
+        )
+
+
+def _episode_source_ref(data: Dict) -> str:
+    keys = ["book", "chapter", "page"]
+    parts = [
+        f"{key} {data[key]}"
+        for key in keys
+        if data[key] is not None
+    ]
+    return ", ".join(parts).capitalize()

--- a/backend/download/export_docx.py
+++ b/backend/download/export_docx.py
@@ -36,12 +36,22 @@ def _add_source(data: Dict, document: DocumentObject) -> None:
     if description := data["description"]:
         document.add_paragraph(description)
 
+    document.add_heading("Episodes", level=2)
     for episode in data["episodes"]:
         _add_episode(episode, data, document)
 
+    document.add_heading("Agents", level=2)
+    for agent in data["agents"]:
+        _add_agent(agent, document)
+
+    for key in ["letters", "gifts", "locations"]:
+        document.add_heading(key.capitalize(), level=2)
+        for agent in data[key]:
+            _add_entity(agent, document)
+
 
 def _add_episode(data: Dict, source_data: Dict, document: DocumentObject) -> None:
-    document.add_heading(data["name"], level=2)
+    document.add_heading(data["name"], level=3)
 
     if source_ref := _episode_source_ref(data["source_reference"]):
         document.add_paragraph(source_ref)
@@ -60,7 +70,11 @@ def _add_episode(data: Dict, source_data: Dict, document: DocumentObject) -> Non
         )
 
     for key in ["agents", "letters", "gifts", "locations"]:
-        _add_episode_entities(data, source_data, key, document)
+        if entities := _episode_entity_names(data, source_data, key):
+            document.add_paragraph()
+            document.add_paragraph(
+                f"{key}: {entities}".capitalize()
+            )
 
 
 def _episode_source_ref(data: Dict) -> str:
@@ -73,13 +87,6 @@ def _episode_source_ref(data: Dict) -> str:
     return ", ".join(parts).capitalize()
 
 
-def _add_episode_entities(episode_data: Dict, source_data: Dict, key: str, document: DocumentObject):
-    if entities := _episode_entity_names(episode_data, source_data, key):
-        document.add_paragraph(
-            f"{key}: {entities}".capitalize()
-        )
-
-
 def _episode_entity_names(episode_data: Dict, source_data: Dict, key: str):
     ids = episode_data[key]
     all_entities = source_data[key]
@@ -89,3 +96,22 @@ def _episode_entity_names(episode_data: Dict, source_data: Dict, key: str):
     ]
     names = [entity["name"] for entity in entities]
     return ", ".join(names)
+
+
+def _add_agent(data: Dict, document: DocumentObject):
+    p = document.add_paragraph(style="List Bullet")
+    name = p.add_run(data["name"])
+    if data["is_group"]:
+        name.add_text(" [group]")
+    name.add_text(". ")
+
+    description = p.add_run(data["description"])
+    description.italic = True
+
+
+def _add_entity(data: Dict, document: DocumentObject):
+    p = document.add_paragraph(style="List Bullet")
+    p.add_run(data["name"] + ". ")
+
+    description = p.add_run(data["description"])
+    description.italic = True

--- a/backend/download/export_docx.py
+++ b/backend/download/export_docx.py
@@ -28,30 +28,39 @@ def _add_source(data: Dict, document: DocumentObject) -> None:
     document.add_page_break()
     document.add_heading(data["name"])
 
-    if len(data["contributors"]):
+    if contributors := data["contributors"]:
         document.add_paragraph(
-            f"Contributors: {", ".join(data["contributors"])}"
+            f"Contributors: {", ".join(contributors)}"
         )
 
-    if data["description"]:
-        document.add_paragraph(data["description"])
+    if description := data["description"]:
+        document.add_paragraph(description)
 
     for episode in data["episodes"]:
-        _add_episode(episode, document)
+        _add_episode(episode, data, document)
 
 
-def _add_episode(data: Dict, document: DocumentObject) -> None:
+def _add_episode(data: Dict, source_data: Dict, document: DocumentObject) -> None:
     document.add_heading(data["name"], level=2)
 
-    source_ref = _episode_source_ref(data["source_reference"])
-    if source_ref:
+    if source_ref := _episode_source_ref(data["source_reference"]):
         document.add_paragraph(source_ref)
 
-    document.add_paragraph(data["summary"])
-    if len(data["designators"]):
+    if summary := data["summary"]:
+        document.add_paragraph(summary)
+
+    if labels := data["labels"]:
         document.add_paragraph(
-            f"Designators: {", ".join(data["designators"])}",
+            f"Labels: {", ".join(labels)}"
         )
+
+    if designators := data["designators"]:
+        document.add_paragraph(
+            f"Designators: {", ".join(designators)}",
+        )
+
+    for key in ["agents", "letters", "gifts", "locations"]:
+        _add_episode_entities(data, source_data, key, document)
 
 
 def _episode_source_ref(data: Dict) -> str:
@@ -62,3 +71,21 @@ def _episode_source_ref(data: Dict) -> str:
         if data[key] is not None
     ]
     return ", ".join(parts).capitalize()
+
+
+def _add_episode_entities(episode_data: Dict, source_data: Dict, key: str, document: DocumentObject):
+    if entities := _episode_entity_names(episode_data, source_data, key):
+        document.add_paragraph(
+            f"{key}: {entities}".capitalize()
+        )
+
+
+def _episode_entity_names(episode_data: Dict, source_data: Dict, key: str):
+    ids = episode_data[key]
+    all_entities = source_data[key]
+    entities = [
+        next(entity for entity in all_entities if entity["id"] == entity_id)
+        for entity_id in ids
+    ]
+    names = [entity["name"] for entity in entities]
+    return ", ".join(names)

--- a/backend/download/export_json.py
+++ b/backend/download/export_json.py
@@ -2,10 +2,12 @@ from typing import Dict, List, Any
 import json
 import re
 from io import TextIOWrapper
+from datetime import date
 
 from django.db.models import QuerySet, Value, CharField
 from django.db.models.functions import Concat, JSONObject, NullIf
 from django.contrib.postgres.aggregates import ArrayAgg
+from django.conf import settings
 
 from source.models import Source
 from person.models import AgentDescription
@@ -14,6 +16,10 @@ from letter.models import LetterDescription, GiftDescription
 from space.models import SpaceDescription
 from user.models import User
 from source.utils import source_contributor_ids
+
+DATE_FORMAT = "%d-%m-%Y"
+SITE_URL = "https://" + settings.HOST
+
 
 def save_json(sources: QuerySet[Source], f: TextIOWrapper) -> None:
     data = json_data(sources)
@@ -26,9 +32,15 @@ def json_data(sources: QuerySet[Source]) -> Dict:
     return cleaned
 
 def _serialize(sources: QuerySet[Source]) -> Dict:
+    timestamp = date.today().strftime(DATE_FORMAT)
     return {
-        'sources': [_serialize_source(source) for source in sources]
+        "sources": [_serialize_source(source) for source in sources],
+        "metadata": {
+            "url": SITE_URL,
+            "date": timestamp,
+        }
     }
+
 
 def _serialize_source(source: Source) -> Dict:
     agents = _serialize_agents(AgentDescription.objects.filter(source=source))

--- a/backend/download/management/commands/export_docx.py
+++ b/backend/download/management/commands/export_docx.py
@@ -3,7 +3,7 @@ import argparse
 from io import TextIOWrapper
 
 from source.models import Source
-from download.export_json import save_json
+from download.export_docx import save_docx
 
 class Command(BaseCommand):
     help = '''
@@ -12,10 +12,14 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):
         parser.add_argument(
-            'out',
-            type=argparse.FileType('w'),
+            "out",
+            type=argparse.FileType("wb"),
         )
 
     def handle(self, out: TextIOWrapper, *args, **kwargs):
         sources = Source.objects.filter(is_public=True)
-        save_json(sources, out)
+
+        save_docx(sources, out)
+        self.stdout.write(self.style.SUCCESS(
+            f"DOCX file saved at {out.name}"
+        ))

--- a/backend/download/management/commands/export_json.py
+++ b/backend/download/management/commands/export_json.py
@@ -1,0 +1,24 @@
+from django.core.management.base import BaseCommand
+import argparse
+from io import TextIOWrapper
+
+from source.models import Source
+from download.export_json import save_json
+
+class Command(BaseCommand):
+    help = '''
+    Export all public data to JSON
+    '''
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "out",
+            type=argparse.FileType("w"),
+        )
+
+    def handle(self, out: TextIOWrapper, *args, **kwargs):
+        sources = Source.objects.filter(is_public=True)
+        save_json(sources, out)
+        self.stdout.write(self.style.SUCCESS(
+            f"JSON file saved at {out.name}"
+        ))

--- a/backend/download/tests/test_export_docx.py
+++ b/backend/download/tests/test_export_docx.py
@@ -1,9 +1,14 @@
 from source.models import Source
 from download.export_docx import save_docx
+from docx import Document
 
 
-def test_export_json(tmp_path, source: Source, episode, episode_2, episode_attribution):
+def test_export_docx(tmp_path, source: Source, episode, episode_2, episode_attribution):
     path = tmp_path / "data.docx"
     qs = Source.objects.filter(pk=source.pk)
     with open(path, "wb") as f:
         save_docx(qs, f)
+
+    with open(path, 'rb') as f:
+        doc = Document(f)
+        assert doc

--- a/backend/download/tests/test_export_docx.py
+++ b/backend/download/tests/test_export_docx.py
@@ -1,0 +1,9 @@
+from source.models import Source
+from download.export_docx import save_docx
+
+
+def test_export_json(tmp_path, source: Source, episode, episode_2, episode_attribution):
+    path = tmp_path / "data.docx"
+    qs = Source.objects.filter(pk=source.pk)
+    with open(path, "wb") as f:
+        save_docx(qs, f)

--- a/backend/download/urls.py
+++ b/backend/download/urls.py
@@ -1,6 +1,7 @@
 from django.urls import path
-from download.views import DownloadJSONView
+from download.views import DownloadJSONView, DownloadDocxView
 
 urlpatterns = [
-    path("download", DownloadJSONView.as_view()),
+    path("download-json", DownloadJSONView.as_view()),
+    path("download-docx", DownloadDocxView.as_view()),
 ]

--- a/backend/download/views.py
+++ b/backend/download/views.py
@@ -1,8 +1,10 @@
 from rest_framework.views import APIView
-from django.http.response import JsonResponse
+from django.http.response import JsonResponse, FileResponse
 from source.models import Source
+import io
 
 from download.export_json import json_data
+from download.export_docx import save_docx
 
 class DownloadJSONView(APIView):
     def get(self, request, *args, **kwargs):
@@ -12,3 +14,12 @@ class DownloadJSONView(APIView):
         return JsonResponse(data, headers={
             "Content-disposition": f"attachment; filename=\"{filename}\"",
         })
+
+
+class DownloadDocxView(APIView):
+    def get(self, request, *args, **kwargs):
+        sources = Source.objects.filter(is_public=True)
+        buffer = io.BytesIO()
+        save_docx(sources, buffer)
+        buffer.seek(0)
+        return FileResponse(buffer, as_attachment=True, filename="lettercraft-data.docx")

--- a/backend/requirements.in
+++ b/backend/requirements.in
@@ -15,3 +15,4 @@ django-filter
 Pillow
 django-prose-editor[sanitize]
 requests
+python-docx

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -71,6 +71,8 @@ idna==3.15
     # via requests
 iniconfig==2.0.0
     # via pytest
+lxml==6.1.1
+    # via python-docx
 nh3==0.2.21
     # via django-prose-editor
 packaging==23.2
@@ -96,6 +98,8 @@ pytest-xdist==3.3.1
     # via -r requirements.in
 python-dateutil==2.8.2
     # via faker
+python-docx==1.2.0
+    # via -r requirements.in
 requests==2.33.1
     # via -r requirements.in
 six==1.16.0
@@ -111,6 +115,8 @@ text-unidecode==1.3
     # via graphene-django
 tornado==6.5.5
     # via django-livereload-server
+typing-extensions==4.15.0
+    # via python-docx
 urllib3==2.7.0
     # via
     #   django-revproxy

--- a/frontend/src/app/data/download/download.component.html
+++ b/frontend/src/app/data/download/download.component.html
@@ -12,18 +12,30 @@
             <p>
                 You can download all data from the Lettercraft project for your own
                 analysis. This includes all sources and data on epistolary episodes.
+                You can download the data as a JSON file or a DOCX file.
             </p>
 
             <p>
-                The data is available as a JSON file, which is suitable for programming
-                languages like Python or R. In the future, we plan to offer
-                other formats as well.
+                The JSON file is most suitable for quantitative analysis, for instance
+                with programming languages like Python or R.
             </p>
 
             <p>
-                <a href="/api/download/download" class="btn btn-primary">
+                <a href="/api/download/download-json" class="btn btn-primary">
                     <lc-icon [icon]="icons.download" class="me-1" />
                     Download data (JSON)
+                </a>
+            </p>
+
+            <p>
+                The DOCX file is most suitable if you want to read or annotate the
+                data in programs like Microsoft Word or Nvivo.
+            </p>
+
+            <p>
+                <a href="/api/download/download-docx" class="btn btn-primary">
+                    <lc-icon [icon]="icons.download" class="me-1" />
+                    Download data (DOCX)
                 </a>
             </p>
         </div>


### PR DESCRIPTION
Builds on #314 - adds the option to download the data as DOCX.

The docx contains almost all the data in the JSON export, except for fields that contain HTML data (source references, most notably). I want to add those too, but I'll pick that up in a separate PR.

Also adds the URL and date to the JSON download.